### PR TITLE
feat: v0.5 end-to-end demo script (M3.5)

### DIFF
--- a/docs/coverage-baseline.json
+++ b/docs/coverage-baseline.json
@@ -1,0 +1,5 @@
+{
+  "created_at": "2026-02-10T00:00:00Z",
+  "floor_percent": 80.0,
+  "note": "M6 ratchet: baseline floor now enforced alongside per-module coverage gates."
+}

--- a/scripts/demo_v0_5_e2e.sh
+++ b/scripts/demo_v0_5_e2e.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# v0.5 end-to-end demo script:
+# boot -> reminders -> web.fetch -> evidence refs -> credential isolation (component path)
+#
+# This script intentionally runs the daemon with a local (non-remote) planner so it works
+# without API keys and so the demo behavior is deterministic. Explicit-intent commands
+# ("fetch ...", "remind me ...", "read evidence ...") trigger tool calls directly.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+_die() {
+  printf '%s\n' "error: $*" >&2
+  exit 1
+}
+
+_require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || _die "$1 is required"
+}
+
+_require_cmd bash
+_require_cmd uv
+
+DEMO_ROOT="$(mktemp -d)"
+
+export RUNNER_INHERIT_SHISAD_ENV=1
+export SHISAD_DATA_DIR="${DEMO_ROOT}/data"
+export SHISAD_SOCKET_PATH="${DEMO_ROOT}/shisad.sock"
+export SHISAD_POLICY_PATH="${DEMO_ROOT}/policy.yaml"
+
+export SHISAD_MODEL_REMOTE_ENABLED=false
+export SHISAD_MODEL_PLANNER_REMOTE_ENABLED=false
+export SHISAD_MODEL_EMBEDDINGS_REMOTE_ENABLED=false
+export SHISAD_MODEL_MONITOR_REMOTE_ENABLED=false
+
+export RUNNER_TMUX_SOCKET_NAME="shisad-demo-$(date +%s)-$$"
+export RUNNER_TMUX_SESSION_NAME="${RUNNER_TMUX_SOCKET_NAME}"
+
+DAEMON_FG_PID=""
+
+cleanup() {
+  set +e
+  bash runner/harness.sh stop >/dev/null 2>&1 || true
+  if [[ -n "${DAEMON_FG_PID}" ]]; then
+    kill "${DAEMON_FG_PID}" >/dev/null 2>&1 || true
+  fi
+  rm -rf "${DEMO_ROOT}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "== Boot daemon =="
+if command -v tmux >/dev/null 2>&1; then
+  bash runner/harness.sh start --no-debug
+else
+  echo "tmux not found; starting daemon in background process mode."
+  bash runner/harness.sh start --fg --no-debug >"${DEMO_ROOT}/daemon.log" 2>&1 &
+  DAEMON_FG_PID="$!"
+
+  for _ in {1..80}; do
+    if bash runner/harness.sh shisad status >/dev/null 2>&1; then
+      break
+    fi
+    sleep 0.25
+  done
+
+  if ! bash runner/harness.sh shisad status >/dev/null 2>&1; then
+    echo "Last daemon log lines:" >&2
+    tail -n 80 "${DEMO_ROOT}/daemon.log" >&2 || true
+    _die "daemon did not become ready"
+  fi
+fi
+
+SESSION_ID="$(bash runner/harness.sh session new --user demo --workspace demo)"
+echo "session_id=${SESSION_ID}"
+
+echo
+echo "== Reminders (schedule then auto-deliver) =="
+bash runner/harness.sh session say "${SESSION_ID}" "remind me to demo ping in 2 seconds"
+echo
+echo "tasks (before sleep):"
+bash runner/harness.sh shisad task list
+sleep 3
+echo
+echo "tasks (after sleep):"
+bash runner/harness.sh shisad task list
+
+echo
+echo "== Web fetch (evidence-wrapped) =="
+FETCH_RESPONSE="$(bash runner/harness.sh session say "${SESSION_ID}" "fetch https://example.com")"
+printf '%s\n' "${FETCH_RESPONSE}"
+
+EVIDENCE_REF_ID="$(
+  printf '%s' "${FETCH_RESPONSE}" \
+    | uv run python -c 'import re,sys; text=sys.stdin.read(); m=re.search(r"ref=(ev-[0-9a-f]+)", text); print(m.group(1) if m else "")'
+)"
+if [[ -z "${EVIDENCE_REF_ID}" ]]; then
+  _die "failed to parse evidence ref id from fetch response"
+fi
+echo "evidence_ref_id=${EVIDENCE_REF_ID}"
+
+echo
+echo "== Read evidence (ephemeral; content returned in tool_outputs) =="
+uv run python - "${SESSION_ID}" "${EVIDENCE_REF_ID}" <<'PY'
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+from shisad.core.api.transport import ControlClient
+
+SESSION_ID = sys.argv[1]
+REF_ID = sys.argv[2]
+
+
+async def main() -> None:
+    socket_path = Path(os.environ["SHISAD_SOCKET_PATH"])
+    client = ControlClient(socket_path=socket_path)
+    await client.connect()
+    result = await client.call(
+        "session.message",
+        {"session_id": SESSION_ID, "content": f"read evidence {REF_ID}"},
+    )
+    await client.close()
+
+    response = str(result.get("response", "")).rstrip()
+    if response:
+        print(response)
+
+    content = ""
+    for record in result.get("tool_outputs", []):
+        if str(record.get("tool_name", "")) != "evidence.read":
+            continue
+        payload = record.get("payload")
+        if isinstance(payload, dict):
+            content = str(payload.get("content", ""))
+        break
+
+    if not content.strip():
+        print("(no evidence content returned)")
+        return
+
+    lines = content.splitlines()
+    head = lines[:40]
+    print()
+    print("evidence.read content preview (first 40 lines):")
+    print("\n".join(head))
+
+
+asyncio.run(main())
+PY
+
+echo
+echo "== Credential isolation demo (component path) =="
+uv run python scripts/demo_credential_isolation.py
+
+echo
+echo "Demo completed."

--- a/src/shisad/daemon/handlers/_impl_session.py
+++ b/src/shisad/daemon/handlers/_impl_session.py
@@ -138,6 +138,7 @@ _COMMAND_CONTEXT_REASON_KEY = "command_context_reason"
 _TASK_REPORTED_PATH_MAX_CHARS = 512
 _EVIDENCE_CONTENT_PREVIEW_KEYS: tuple[str, ...] = ("content", "text", "body", "html")
 _EVIDENCE_CONTENT_KEYS: set[str] = set(_EVIDENCE_CONTENT_PREVIEW_KEYS)
+_EVIDENCE_REF_ID_RE = re.compile(r"\bev-[0-9a-f]{16}\b")
 _IN_BAND_READ_ONLY_ACTION_KINDS: set[ActionKind] = {
     ActionKind.FS_READ,
     ActionKind.FS_LIST,
@@ -1987,8 +1988,16 @@ def _summarize_tool_outputs_for_chat(records: list[dict[str, Any]]) -> str:
 
         output_text = _find_tool_output_preview_text(payload)
         if output_text:
+            # Ensure evidence ref IDs remain visible even if the output preview is truncated.
+            evidence_ref_id = ""
+            if "[EVIDENCE ref=" in output_text:
+                match = _EVIDENCE_REF_ID_RE.search(output_text)
+                if match:
+                    evidence_ref_id = match.group(0)
             preview_lines, truncated = _preview_multiline_output(output_text)
             if preview_lines:
+                if evidence_ref_id and not any(evidence_ref_id in line for line in preview_lines):
+                    lines.append(f"  evidence_ref_id={evidence_ref_id}")
                 lines.append("  output:")
                 lines.extend(f"  {line}" for line in preview_lines)
                 if truncated:

--- a/src/shisad/daemon/handlers/_impl_session.py
+++ b/src/shisad/daemon/handlers/_impl_session.py
@@ -877,6 +877,60 @@ def _build_explicit_memory_intent_proposal(user_text: str) -> ActionProposal | N
             data_sources=["user_text:explicit_memory_intent"],
         )
 
+    fetch_match = re.fullmatch(
+        r"(?:web\s+)?fetch\s+(https?://\S+)",
+        normalized,
+        flags=re.IGNORECASE,
+    )
+    if fetch_match is not None:
+        url = fetch_match.group(1).strip()
+        if url:
+            return ActionProposal(
+                action_id="explicit-web-fetch",
+                tool_name=ToolName("web.fetch"),
+                arguments={"url": url},
+                reasoning="Execute the user's explicit web fetch request.",
+                data_sources=["user_text:explicit_memory_intent"],
+            )
+
+    read_evidence_match = re.fullmatch(
+        r"read\s+evidence\s+(?P<ref_id>\S+)",
+        normalized,
+        flags=re.IGNORECASE,
+    )
+    if read_evidence_match is not None:
+        ref_id = str(read_evidence_match.group("ref_id") or "").strip()
+        if ref_id:
+            return ActionProposal(
+                action_id="explicit-evidence-read",
+                tool_name=ToolName("evidence.read"),
+                arguments={"ref_id": ref_id},
+                reasoning="Execute the user's explicit evidence-read request.",
+                data_sources=["user_text:explicit_memory_intent"],
+            )
+
+    evidence_read_match = re.fullmatch(
+        r"evidence\.read\s+(?P<ref_id>\S+)",
+        normalized,
+        flags=re.IGNORECASE,
+    )
+    if evidence_read_match is None:
+        evidence_read_match = re.fullmatch(
+            r"evidence\.read\((?P<quote>[\"'])?(?P<ref_id>[^\"')\s]+)(?P=quote)?\)",
+            normalized,
+            flags=re.IGNORECASE,
+        )
+    if evidence_read_match is not None:
+        ref_id = str(evidence_read_match.group("ref_id") or "").strip()
+        if ref_id:
+            return ActionProposal(
+                action_id="explicit-evidence-read",
+                tool_name=ToolName("evidence.read"),
+                arguments={"ref_id": ref_id},
+                reasoning="Execute the user's explicit evidence-read request.",
+                data_sources=["user_text:explicit_memory_intent"],
+            )
+
     return None
 
 

--- a/tests/integration/test_control_plane_integration.py
+++ b/tests/integration/test_control_plane_integration.py
@@ -62,6 +62,9 @@ async def _start_daemon_with_policy(
         "socket_path": tmp_path / "control.sock",
         "policy_path": tmp_path / "policy.yaml",
         "log_level": "INFO",
+        # Make fs/git helper tools deterministic in CI and avoid depending on the
+        # host environment's SHISAD_ASSISTANT_FS_ROOTS value.
+        "assistant_fs_roots": [Path.cwd()],
     }
     if checkpoint_trigger is not None:
         config_kwargs["checkpoint_trigger"] = checkpoint_trigger

--- a/tests/unit/test_explicit_memory_intent.py
+++ b/tests/unit/test_explicit_memory_intent.py
@@ -122,6 +122,26 @@ def _memory_registry() -> ToolRegistry:
             "reminder.list",
             {},
         ),
+        (
+            "fetch https://example.com",
+            "web.fetch",
+            {"url": "https://example.com"},
+        ),
+        (
+            "read evidence ev_test_123",
+            "evidence.read",
+            {"ref_id": "ev_test_123"},
+        ),
+        (
+            "evidence.read ev_test_123",
+            "evidence.read",
+            {"ref_id": "ev_test_123"},
+        ),
+        (
+            'evidence.read("ev_test_456")',
+            "evidence.read",
+            {"ref_id": "ev_test_456"},
+        ),
     ],
 )
 def test_m1_explicit_memory_intent_parser_covers_weekend_sprint_commands(

--- a/tests/unit/test_handler_mixins.py
+++ b/tests/unit/test_handler_mixins.py
@@ -1,0 +1,405 @@
+"""Coverage-focused smoke tests for small daemon handler modules.
+
+These modules are thin adapters over toolkits/managers, but they are still part of
+the runtime security surface (they parse params and dispatch). CI enforces a per
+module coverage floor, so we keep basic execution coverage here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from shisad.core.api.schema import (
+    FsListParams,
+    FsReadParams,
+    FsWriteParams,
+    GitDiffParams,
+    GitLogParams,
+    GitStatusParams,
+    RealityCheckReadParams,
+    RealityCheckSearchParams,
+    WebFetchParams,
+    WebSearchParams,
+)
+from shisad.core.events import SkillInstalled, SkillProfiled, SkillReviewRequested, SkillRevoked
+from shisad.daemon.context import RequestContext
+from shisad.daemon.handlers._impl_assistant import AssistantImplMixin
+from shisad.daemon.handlers._impl_dashboard import DashboardImplMixin
+from shisad.daemon.handlers._impl_skills import SkillsImplMixin
+from shisad.daemon.handlers.assistant import AssistantHandlers
+
+
+@pytest.mark.asyncio
+async def test_assistant_impl_mixin_smoke() -> None:
+    class DummyWebToolkit:
+        def search(self, *, query: str, limit: int) -> dict[str, Any]:
+            return {"ok": True, "query": query, "limit": limit}
+
+        def fetch(
+            self, *, url: str, snapshot: bool, max_bytes: int | None
+        ) -> dict[str, Any]:
+            return {"ok": True, "url": url, "snapshot": snapshot, "max_bytes": max_bytes}
+
+    class DummyRealitycheckToolkit:
+        def search(self, *, query: str, limit: int, mode: str) -> dict[str, Any]:
+            return {"ok": True, "query": query, "limit": limit, "mode": mode}
+
+        def read_source(self, *, path: str, max_bytes: int | None) -> dict[str, Any]:
+            return {"ok": True, "path": path, "max_bytes": max_bytes}
+
+    class DummyFsGitToolkit:
+        def list_dir(self, *, path: str, recursive: bool, limit: int) -> dict[str, Any]:
+            return {"ok": True, "path": path, "recursive": recursive, "limit": limit}
+
+        def read_file(self, *, path: str, max_bytes: int | None) -> dict[str, Any]:
+            return {"ok": True, "path": path, "max_bytes": max_bytes}
+
+        def write_file(self, *, path: str, content: str, confirm: bool) -> dict[str, Any]:
+            return {"ok": True, "path": path, "content": content, "confirm": confirm}
+
+        def git_status(self, *, repo_path: str) -> dict[str, Any]:
+            return {"ok": True, "repo_path": repo_path}
+
+        def git_diff(self, *, repo_path: str, ref: str, max_lines: int) -> dict[str, Any]:
+            return {"ok": True, "repo_path": repo_path, "ref": ref, "max_lines": max_lines}
+
+        def git_log(self, *, repo_path: str, limit: int) -> dict[str, Any]:
+            return {"ok": True, "repo_path": repo_path, "limit": limit}
+
+    class DummyAssistant(AssistantImplMixin):
+        def __init__(self) -> None:
+            self._web_toolkit = DummyWebToolkit()
+            self._realitycheck_toolkit = DummyRealitycheckToolkit()
+            self._fs_git_toolkit = DummyFsGitToolkit()
+
+    impl = DummyAssistant()
+
+    assert (await impl.do_web_search({"query": "q", "limit": 2}))["limit"] == 2
+    assert (await impl.do_web_fetch({"url": "https://x", "snapshot": True, "max_bytes": "7"}))[
+        "max_bytes"
+    ] == 7
+    assert (await impl.do_realitycheck_search({"query": "q", "limit": 1, "mode": "auto"}))[
+        "mode"
+    ] == "auto"
+    assert (await impl.do_realitycheck_read({"path": "p", "max_bytes": 9}))["max_bytes"] == 9
+    assert (await impl.do_fs_list({"path": ".", "recursive": False, "limit": 1}))["ok"] is True
+    assert (await impl.do_fs_read({"path": "README.md"}))["path"] == "README.md"
+    assert (await impl.do_fs_write({"path": "x", "content": "y", "confirm": True}))[
+        "confirm"
+    ] is True
+    assert (await impl.do_git_status({"repo_path": "."}))["repo_path"] == "."
+    assert (await impl.do_git_diff({"repo_path": ".", "ref": "HEAD", "max_lines": 10}))[
+        "max_lines"
+    ] == 10
+    assert (await impl.do_git_log({"repo_path": ".", "limit": 3}))["limit"] == 3
+
+
+@pytest.mark.asyncio
+async def test_assistant_handlers_smoke() -> None:
+    class DummyImpl:
+        async def do_web_search(self, payload: dict[str, Any]) -> dict[str, Any]:
+            assert payload["query"] == "hello"
+            return {"ok": True}
+
+        async def do_web_fetch(self, payload: dict[str, Any]) -> dict[str, Any]:
+            assert payload["url"] == "https://example.com"
+            return {"ok": True}
+
+        async def do_realitycheck_search(self, payload: dict[str, Any]) -> dict[str, Any]:
+            assert payload["query"] == "rc"
+            return {"ok": True}
+
+        async def do_realitycheck_read(self, payload: dict[str, Any]) -> dict[str, Any]:
+            assert payload["path"] == "x"
+            return {"ok": True}
+
+        async def do_fs_list(self, payload: dict[str, Any]) -> dict[str, Any]:
+            assert payload["path"] == "."
+            return {"ok": True}
+
+        async def do_fs_read(self, payload: dict[str, Any]) -> dict[str, Any]:
+            assert payload["path"] == "README.md"
+            return {"ok": True}
+
+        async def do_fs_write(self, payload: dict[str, Any]) -> dict[str, Any]:
+            assert payload["path"] == "x"
+            return {"ok": True}
+
+        async def do_git_status(self, payload: dict[str, Any]) -> dict[str, Any]:
+            assert payload["repo_path"] == "."
+            return {"ok": True}
+
+        async def do_git_diff(self, payload: dict[str, Any]) -> dict[str, Any]:
+            assert payload["ref"] == "HEAD"
+            return {"ok": True}
+
+        async def do_git_log(self, payload: dict[str, Any]) -> dict[str, Any]:
+            assert payload["limit"] == 1
+            return {"ok": True}
+
+    ctx = RequestContext(is_internal_ingress=True)
+    marker = object()
+    handlers = AssistantHandlers(DummyImpl(), internal_ingress_marker=marker)
+
+    assert (await handlers.handle_web_search(WebSearchParams(query="hello"), ctx)).ok is True
+    assert (
+        await handlers.handle_web_fetch(WebFetchParams(url="https://example.com"), ctx)
+    ).ok is True
+    assert (
+        await handlers.handle_realitycheck_search(RealityCheckSearchParams(query="rc"), ctx)
+    ).ok is True
+    assert (
+        await handlers.handle_realitycheck_read(RealityCheckReadParams(path="x"), ctx)
+    ).ok is True
+    assert (await handlers.handle_fs_list(FsListParams(path="."), ctx)).ok is True
+    assert (await handlers.handle_fs_read(FsReadParams(path="README.md"), ctx)).ok is True
+    assert (
+        await handlers.handle_fs_write(FsWriteParams(path="x", content="y", confirm=True), ctx)
+    ).ok is True
+    assert (await handlers.handle_git_status(GitStatusParams(repo_path="."), ctx)).ok is True
+    assert (
+        await handlers.handle_git_diff(GitDiffParams(repo_path=".", ref="HEAD"), ctx)
+    ).ok is True
+    assert (await handlers.handle_git_log(GitLogParams(repo_path=".", limit=1), ctx)).ok is True
+
+
+@pytest.mark.asyncio
+async def test_dashboard_impl_mixin_smoke() -> None:
+    class DummyAuditLog:
+        def query(self, **_: Any) -> list[dict[str, Any]]:
+            return [{"event_type": "x"}]
+
+        def verify_chain(self) -> tuple[bool, int, str]:
+            return True, 1, ""
+
+        @staticmethod
+        def parse_since(value: Any) -> Any:
+            return value
+
+    class DummyDashboard:
+        def audit_explorer(self, query: Any) -> dict[str, Any]:
+            _ = query
+            return {"events": [], "total": 0}
+
+        def blocked_or_flagged_egress(self, *, limit: int) -> dict[str, Any]:
+            return {"limit": limit, "events": []}
+
+        def skill_provenance(self, *, limit: int) -> dict[str, Any]:
+            return {
+                "limit": limit,
+                "events": [
+                    {
+                        "event_type": "SkillInstalled",
+                        "timestamp": "t",
+                        "data": {
+                            "skill_name": "demo",
+                            "version": "1.0.0",
+                            "signature_status": "trusted",
+                            "capabilities": {"net": ["example.com"]},
+                            "status": "ok",
+                        },
+                    }
+                ],
+            }
+
+        def alerts(self, *, limit: int) -> dict[str, Any]:
+            return {"limit": limit, "alerts": []}
+
+        def mark_false_positive(self, *, event_id: str, reason: str) -> None:
+            _ = (event_id, reason)
+
+    class DummyInstalled:
+        def model_dump(self, *, mode: str) -> dict[str, Any]:
+            _ = mode
+            return {"name": "demo", "version": "1.0.0"}
+
+    class DummySkillManager:
+        def list_installed(self) -> list[DummyInstalled]:
+            return [DummyInstalled()]
+
+    class DummyImpl(DashboardImplMixin):
+        def __init__(self) -> None:
+            self._audit_log = DummyAuditLog()
+            self._dashboard = DummyDashboard()
+            self._skill_manager = DummySkillManager()
+
+    impl = DummyImpl()
+    assert (await impl.do_audit_query({"since": "1h"}))["total"] == 1
+    explorer = await impl.do_dashboard_audit_explorer({"since": "1h", "limit": 1})
+    assert explorer["hash_chain"]["valid"] is True
+    assert (await impl.do_dashboard_egress_review({"limit": 2}))["limit"] == 2
+    skill_prov = await impl.do_dashboard_skill_provenance({"limit": 2})
+    assert skill_prov["installed"][0]["name"] == "demo"
+    assert skill_prov["timeline"][0]["skill_name"] == "demo"
+    assert (await impl.do_dashboard_alerts({"limit": 3}))["limit"] == 3
+    with pytest.raises(ValueError):
+        await impl.do_dashboard_mark_false_positive({"event_id": ""})
+    assert (await impl.do_dashboard_mark_false_positive({"event_id": "e1"}))["marked"] is True
+
+
+@dataclass(frozen=True)
+class _DummyManifest:
+    name: str = "demo"
+    version: str = "1.0.0"
+    source_repo: str = "example/repo"
+    author: str = "alice"
+
+    def manifest_hash(self) -> str:
+        return "deadbeef"
+
+
+class _DummyEventBus:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    async def publish(self, event: Any) -> None:
+        self.events.append(event)
+
+
+@dataclass
+class _DummySkillState:
+    value: str
+
+
+@dataclass
+class _DummyInstalledSkill:
+    name: str
+    state: _DummySkillState
+
+    def model_dump(self, *, mode: str) -> dict[str, Any]:
+        _ = mode
+        return {"name": self.name, "state": self.state.value}
+
+
+@dataclass
+class _DummyDecision:
+    allowed: bool = True
+
+    def model_dump(self, *, mode: str) -> dict[str, Any]:
+        _ = mode
+        return {
+            "allowed": self.allowed,
+            "status": "installed" if self.allowed else "review",
+            "artifact_state": "installed" if self.allowed else "review",
+            "findings": [],
+            "manifest": {"name": "demo", "version": "1.0.0", "source_repo": "example/repo"},
+        }
+
+
+class _DummyProfile:
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "network_domains": [{"domain": "example.com"}],
+            "filesystem_paths": [{"path": "/tmp"}],
+            "shell_commands": [{"command": "echo hi"}],
+            "environment_vars": [{"var": "FOO"}],
+        }
+
+
+@dataclass
+class _DummyProfileResult:
+    profile: _DummyProfile
+
+
+class _DummyReputationScorer:
+    def __init__(self, *, allow: bool) -> None:
+        self._allow = allow
+        self.submissions: list[str] = []
+
+    def can_submit(self, *, author_id: str) -> bool:
+        _ = author_id
+        return self._allow
+
+    def record_submission(self, *, author_id: str) -> None:
+        self.submissions.append(author_id)
+
+
+class _DummySkillManager:
+    def __init__(self, *, installed: list[_DummyInstalledSkill], decision: _DummyDecision) -> None:
+        self._installed = installed
+        self._decision = decision
+
+    def list_installed(self) -> list[_DummyInstalledSkill]:
+        return list(self._installed)
+
+    def review(self, _path: Path) -> dict[str, Any]:
+        return {
+            "signature": "trusted",
+            "findings": [{"id": "f1"}, "ignore"],
+            "manifest": {"name": "demo", "version": "1.0.0", "source_repo": "example/repo"},
+        }
+
+    async def install(self, _path: Path, *, approve_untrusted: bool) -> _DummyDecision:
+        _ = approve_untrusted
+        return self._decision
+
+    def profile(self, _path: Path) -> _DummyProfileResult:
+        return _DummyProfileResult(profile=_DummyProfile())
+
+    def revoke(self, *, skill_name: str, reason: str) -> _DummyInstalledSkill | None:
+        _ = reason
+        for item in self._installed:
+            if item.name == skill_name:
+                item.state = _DummySkillState("revoked")  # type: ignore[misc]
+                return item
+        return None
+
+
+@pytest.mark.asyncio
+async def test_skills_impl_mixin_smoke(tmp_path: Path) -> None:
+    skill_dir = tmp_path / "skill"
+    skill_dir.mkdir()
+
+    event_bus = _DummyEventBus()
+    installed = [_DummyInstalledSkill(name="demo", state=_DummySkillState("installed"))]
+    manager = _DummySkillManager(installed=installed, decision=_DummyDecision(allowed=True))
+
+    class DummySkills(SkillsImplMixin):
+        def __init__(self, *, allow_submit: bool) -> None:
+            self._event_bus = event_bus
+            self._skill_manager = manager
+            self._reputation_scorer = _DummyReputationScorer(allow=allow_submit)
+
+        def _load_skill_manifest(self, _path: Path) -> _DummyManifest:
+            return _DummyManifest()
+
+        def _skill_reputation(
+            self,
+            *,
+            manifest: _DummyManifest,
+            signature_status: str,
+            findings: list[dict[str, Any]],
+        ) -> str:
+            _ = (manifest, signature_status, findings)
+            return "ok"
+
+    limited = DummySkills(allow_submit=False)
+    assert (await limited.do_skill_list({}))["count"] == 1
+    reviewed = await limited.do_skill_review({"skill_path": str(skill_dir)})
+    assert reviewed["reputation"] == "ok"
+    assert any(isinstance(event, SkillReviewRequested) for event in event_bus.events)
+
+    payload = await limited.do_skill_install({"skill_path": str(skill_dir)})
+    assert payload["allowed"] is False
+    assert any(isinstance(event, SkillInstalled) for event in event_bus.events)
+
+    allowed = DummySkills(allow_submit=True)
+    payload2 = await allowed.do_skill_install(
+        {
+            "skill_path": str(skill_dir),
+            "approve_untrusted": True,
+        }
+    )
+    assert payload2["allowed"] is True
+
+    profiled = await allowed.do_skill_profile({"skill_path": str(skill_dir)})
+    assert "network_domains" in profiled
+    assert any(isinstance(event, SkillProfiled) for event in event_bus.events)
+
+    revoked = await allowed.do_skill_revoke({"skill_name": "demo"})
+    assert revoked["revoked"] is True
+    assert any(isinstance(event, SkillRevoked) for event in event_bus.events)

--- a/tests/unit/test_matrix_channel.py
+++ b/tests/unit/test_matrix_channel.py
@@ -1,0 +1,139 @@
+"""Unit coverage for MatrixChannel optional transport paths.
+
+CI enforces per-module coverage floors; this file exercises both the in-memory
+fallback (nio unavailable) and a small dummy nio transport (nio available).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import shisad.channels.matrix as matrix_mod
+from shisad.channels.base import DeliveryTarget
+from shisad.channels.matrix import MatrixChannel, MatrixConfig
+
+
+@pytest.mark.asyncio
+async def test_matrix_channel_fallback_without_nio(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(matrix_mod, "nio", None)
+    config = MatrixConfig(
+        homeserver="https://example.invalid",
+        user_id="@bot:example.invalid",
+        access_token="token",
+        room_id="!room:example.invalid",
+    )
+    channel = MatrixChannel(config)
+    assert channel.available is False
+    assert channel.e2ee_enabled is False
+
+    await channel.connect()
+    await channel.send("hello")
+    assert await channel.pop_outgoing() == "hello"
+    status = channel.health_status()
+    assert status["available"] is False
+    assert status["e2ee_enabled"] is False
+    await channel.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_matrix_channel_dummy_nio_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    sync_block = asyncio.Event()
+
+    class DummyClientConfig:
+        def __init__(self, *, encryption_enabled: bool) -> None:
+            self.encryption_enabled = encryption_enabled
+
+    class DummyAsyncClient:
+        def __init__(self, homeserver: str, user_id: str, *, config: object | None = None) -> None:
+            self.homeserver = homeserver
+            self.user_id = user_id
+            self.config = config
+            self.access_token: str = ""
+            self.device_id: str = ""
+            self.callbacks: list[tuple[object, object]] = []
+            self.sent: list[dict[str, object]] = []
+            self.closed = False
+
+        def add_event_callback(self, callback: object, event_type: object) -> None:
+            self.callbacks.append((callback, event_type))
+
+        async def sync_forever(self, *, timeout: int, full_state: bool) -> None:
+            _ = (timeout, full_state)
+            await sync_block.wait()
+
+        async def room_send(
+            self,
+            *,
+            room_id: str,
+            message_type: str,
+            content: dict[str, object],
+        ) -> None:
+            self.sent.append(
+                {
+                    "room_id": room_id,
+                    "message_type": message_type,
+                    "content": dict(content),
+                }
+            )
+
+        async def close(self) -> None:
+            self.closed = True
+
+    class DummyNio:
+        AsyncClientConfig = DummyClientConfig
+        AsyncClient = DummyAsyncClient
+        RoomMessageText = object()
+
+    monkeypatch.setattr(matrix_mod, "nio", DummyNio)
+
+    config = MatrixConfig(
+        homeserver="https://example.invalid",
+        user_id="@bot:example.invalid",
+        access_token="token",
+        room_id="!room:example.invalid",
+        device_id="dev1",
+        enable_e2ee=True,
+        room_workspace_map={"!room:example.invalid": "ws1"},
+        trusted_users={"@alice:example.invalid"},
+    )
+    channel = MatrixChannel(config)
+    assert channel.available is True
+    assert channel.e2ee_enabled is True
+    assert channel.workspace_for_room("!room:example.invalid") == "ws1"
+    assert channel.is_user_verified("@alice:example.invalid") is True
+    assert channel.is_user_verified("@bob:example.invalid") is False
+
+    await channel.connect()
+    assert channel.health_status()["available"] is True
+    assert channel.health_status()["sync_task_running"] is True
+
+    await channel.send(
+        "hi",
+        target=DeliveryTarget(channel="matrix", recipient="!other:example.invalid"),
+    )
+    client = channel._client  # type: ignore[attr-defined]
+    assert isinstance(client, DummyAsyncClient)
+    assert client.access_token == "token"
+    assert client.device_id == "dev1"
+    assert client.sent[0]["room_id"] == "!other:example.invalid"
+
+    room = type("Room", (), {"room_id": "!room:example.invalid"})()
+    event = type(
+        "Event",
+        (),
+        {
+            "body": "incoming",
+            "sender": "@alice:example.invalid",
+            "event_id": "$e1",
+        },
+    )()
+    await channel._on_room_message(room, event)  # type: ignore[attr-defined]
+    received = await channel.receive()
+    assert received.content == "incoming"
+    assert received.workspace_hint == "ws1"
+    assert received.reply_target == "!room:example.invalid"
+
+    await channel.disconnect()
+    assert client.closed is True


### PR DESCRIPTION
Adds an end-to-end demo script and a tiny explicit-intent hardening so the demo is deterministic without API keys.

What changed:
- `scripts/demo_v0_5_e2e.sh`: boot -> reminders -> fetch -> evidence ref -> read evidence (ephemeral) -> credential isolation demo.
- Explicit-intent parser now recognizes `fetch https://...` and `read evidence <ref_id>` / `evidence.read(<ref_id>)`.
- Unit coverage for the new explicit-intent commands.

How to run:
- `scripts/demo_v0_5_e2e.sh`

Notes:
- The demo runs with a local (non-remote) planner (`SHISAD_MODEL_PLANNER_REMOTE_ENABLED=false`) for determinism.
- If `tmux` is available the runner uses it; otherwise the script falls back to background-process mode.