### PR TITLE
fix: planner route fallback messages for 5xx vs 4xx (#38)

### DIFF
--- a/src/shisad/core/providers/local_planner.py
+++ b/src/shisad/core/providers/local_planner.py
@@ -207,10 +207,57 @@ def _is_structured_task_close_gate_prompt(text: str) -> bool:
     )
 
 
+def _route_error_user_guidance(route_failure: BaseException | None) -> str:
+    """Tailor planner route-fallback guidance to the failure class (issue #38)."""
+    if route_failure is None:
+        return (
+            " Check provider connectivity or credentials, then run "
+            "`shisad doctor check --component provider`."
+        )
+
+    msg = str(route_failure)
+    http_match = re.match(r"Provider HTTP error (\d{3}) ", msg)
+    if http_match:
+        code = int(http_match.group(1))
+        if 500 <= code <= 599:
+            return (
+                f" The configured provider returned HTTP {code} (usually a transient capacity or "
+                "outage issue on the provider side). Retry in a few minutes. Run "
+                "`shisad doctor check --component provider` if it persists."
+            )
+        if 400 <= code <= 499:
+            return (
+                " Check provider connectivity or credentials, then run "
+                "`shisad doctor check --component provider`."
+            )
+        return (
+            f" The planner route returned HTTP {code}. Run "
+            "`shisad doctor check --component provider` for diagnostics."
+        )
+
+    if msg.startswith("Provider request failed for "):
+        return (
+            " Could not reach the provider (connection error). Check your network or run "
+            "`shisad doctor check --component provider`."
+        )
+
+    if isinstance(route_failure, OSError):
+        return (
+            " Could not reach the provider (connection error). Check your network or run "
+            "`shisad doctor check --component provider`."
+        )
+
+    return (
+        " Check provider connectivity or credentials, then run "
+        "`shisad doctor check --component provider`."
+    )
+
+
 def _planner_fallback_message(
     *,
     fallback_mode: str,
     deterministic_tools_available: bool,
+    route_failure: BaseException | None = None,
 ) -> str:
     if fallback_mode == "route_error":
         prefix = _PLANNER_FALLBACK_ROUTE_ERROR_PREFIX
@@ -220,10 +267,7 @@ def _planner_fallback_message(
             if deterministic_tools_available
             else " Conversational planning is unavailable until the planner route recovers."
         )
-        guidance = (
-            " Check provider connectivity or credentials, then run "
-            "`shisad doctor check --component provider`."
-        )
+        guidance = _route_error_user_guidance(route_failure)
         return f"{prefix} {intro}{detail}{guidance}"
 
     prefix = _PLANNER_FALLBACK_CONFIGURATION_PREFIX
@@ -250,6 +294,7 @@ class LocalPlannerProvider:
         tools: list[dict[str, Any]] | None = None,
         *,
         fallback_mode: str = "configuration",
+        planner_route_failure: BaseException | None = None,
     ) -> ProviderResponse:
         _ = tools
         user_content = messages[-1].content if messages else ""
@@ -367,6 +412,7 @@ class LocalPlannerProvider:
         assistant_content = _planner_fallback_message(
             fallback_mode=fallback_mode,
             deterministic_tools_available=bool(tool_calls),
+            route_failure=planner_route_failure if fallback_mode == "route_error" else None,
         )
         return ProviderResponse(
             message=Message(

--- a/src/shisad/core/providers/routed_openai.py
+++ b/src/shisad/core/providers/routed_openai.py
@@ -76,19 +76,17 @@ class RoutedOpenAIProvider:
         tools: list[dict[str, Any]] | None,
         *,
         fallback_mode: str,
+        planner_route_failure: BaseException | None = None,
     ) -> ProviderResponse:
         if self._fallback is None:
             raise RuntimeError("planner fallback unavailable")
-        supports_fallback_mode = (
-            "fallback_mode" in inspect.signature(self._fallback.complete).parameters
-        )
-        if supports_fallback_mode:
-            return await self._fallback.complete(
-                messages,
-                tools,
-                fallback_mode=fallback_mode,
-            )
-        return await self._fallback.complete(messages, tools)
+        params = inspect.signature(self._fallback.complete).parameters
+        kwargs: dict[str, Any] = {}
+        if "fallback_mode" in params:
+            kwargs["fallback_mode"] = fallback_mode
+        if "planner_route_failure" in params:
+            kwargs["planner_route_failure"] = planner_route_failure
+        return await self._fallback.complete(messages, tools, **kwargs)
 
     @staticmethod
     def _build_route_provider(
@@ -180,6 +178,7 @@ class RoutedOpenAIProvider:
                 messages,
                 tools,
                 fallback_mode="route_error",
+                planner_route_failure=exc,
             )
 
     async def embeddings(

--- a/tests/unit/test_providers_extracted.py
+++ b/tests/unit/test_providers_extracted.py
@@ -729,3 +729,119 @@ async def test_u3_routed_openai_provider_distinguishes_route_failure_from_unconf
     )
     assert "shisad doctor check --component provider" in response.message.content
     assert "No language model configured." not in response.message.content
+
+
+@pytest.mark.asyncio
+async def test_local_planner_route_error_5xx_does_not_blame_credentials() -> None:
+    provider = LocalPlannerProvider()
+    exc = RuntimeError(
+        'Provider HTTP error 529 for https://api.anthropic.com/v1/chat/completions: '
+        '{"error":{"type":"overloaded_error"}}'
+    )
+    response = await provider.complete(
+        [Message(role="user", content="hello")],
+        fallback_mode="route_error",
+        planner_route_failure=exc,
+    )
+    text = response.message.content
+    assert "HTTP 529" in text
+    assert "credentials" not in text.lower()
+    assert "transient" in text.lower() or "capacity" in text.lower() or "outage" in text.lower()
+
+
+@pytest.mark.asyncio
+async def test_local_planner_route_error_4xx_mentions_credentials() -> None:
+    provider = LocalPlannerProvider()
+    exc = RuntimeError(
+        "Provider HTTP error 401 for https://api.example.com/v1/chat/completions: unauthorized"
+    )
+    response = await provider.complete(
+        [Message(role="user", content="hello")],
+        fallback_mode="route_error",
+        planner_route_failure=exc,
+    )
+    text = response.message.content
+    assert "credentials" in text.lower()
+
+
+@pytest.mark.asyncio
+async def test_local_planner_route_error_provider_request_failed_is_network_guidance() -> None:
+    provider = LocalPlannerProvider()
+    exc = RuntimeError("Provider request failed for https://api.example.com/v1/chat/completions: ")
+    response = await provider.complete(
+        [Message(role="user", content="hello")],
+        fallback_mode="route_error",
+        planner_route_failure=exc,
+    )
+    text = response.message.content
+    assert "connection error" in text.lower()
+    assert "credentials" not in text.lower()
+
+
+@pytest.mark.asyncio
+async def test_routed_openai_planner_fallback_surfaces_http_529_in_user_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SHISAD_MODEL_REMOTE_ENABLED", "true")
+    monkeypatch.setenv("SHISAD_MODEL_BASE_URL", "https://api.example.com/v1")
+    monkeypatch.setenv("SHISAD_MODEL_PLANNER_BASE_URL", "https://planner.example.com/v1")
+    monkeypatch.setenv("SHISAD_MODEL_API_KEY", "token")
+
+    class _OverloadedOpenAIProvider:
+        def __init__(
+            self,
+            *,
+            base_url: str,
+            model_id: str,
+            headers: dict[str, str],
+            force_json_response: bool = False,
+            request_parameters: Any | None = None,
+            allow_http_localhost: bool = True,
+            block_private_ranges: bool = True,
+            endpoint_allowlist: list[str] | None = None,
+        ) -> None:
+            _ = (
+                base_url,
+                model_id,
+                headers,
+                force_json_response,
+                request_parameters,
+                allow_http_localhost,
+                block_private_ranges,
+                endpoint_allowlist,
+            )
+
+        async def complete(
+            self,
+            messages: list[Message],
+            tools: list[dict[str, Any]] | None = None,
+        ) -> ProviderResponse:
+            _ = (messages, tools)
+            raise RuntimeError(
+                "Provider HTTP error 529 for https://planner.example.com/v1/chat/completions: "
+                '{"error":{"type":"overloaded_error","message":"Overloaded"}}'
+            )
+
+        async def embeddings(
+            self,
+            input_texts: list[str],
+            *,
+            model_id: str | None = None,
+        ) -> EmbeddingResponse:
+            _ = (input_texts, model_id)
+            raise RuntimeError("not used")
+
+    monkeypatch.setattr(
+        "shisad.core.providers.routed_openai.OpenAICompatibleProvider",
+        _OverloadedOpenAIProvider,
+    )
+
+    provider = RoutedOpenAIProvider(
+        router=ModelRouter(ModelConfig()),
+        api_key="token",
+        fallback=LocalPlannerProvider(),
+    )
+
+    response = await provider.complete([Message(role="user", content="hello")])
+    assert "HTTP 529" in response.message.content
+    assert "credentials" not in response.message.content.lower()


### PR DESCRIPTION
## Summary

- Pass the planner route exception from `RoutedOpenAIProvider` into `LocalPlannerProvider` so fallback copy can reflect what actually failed.
- **HTTP 5xx** (e.g. 529 overload): user text explains transient provider-side capacity/outage, includes the concrete status code, and avoids blaming credentials.
- **HTTP 4xx**: keep the existing “connectivity or credentials” guidance.
- **`Provider request failed` / `OSError`**: distinct “could not reach the provider (connection error)” guidance.

Closes #38.

## Test plan

- [x] `pytest tests/unit/test_providers_extracted.py` (20 passed)

Made with [Cursor](https://cursor.com)