### PR TITLE
fix: gate browser tools on runtime health

### DIFF
--- a/docs/analysis/browser-health-gating.md
+++ b/docs/analysis/browser-health-gating.md
@@ -58,3 +58,13 @@ Fix the runtime-facing browser availability bug exposed by the Tabelog reservati
   passed: `2 passed, 54 deselected`.
 - CI follow-up, static checks:
   `uv run ruff check src/ tests/ scripts/` passed.
+- CI follow-up, GitHub hosted runner failure:
+  run `26094226652` failed in `security-runtime` and `lint-and-test (3.12)`
+  because `tests/unit/test_daemon_services.py::test_m6_daemon_services_browser_registry_falls_back_to_web_allowlist`
+  expected browser status `ok` while the hosted runner reported
+  `browser_runtime_isolation_unavailable`. The test was updated to set
+  `browser_require_hardened_isolation=False` because it covers valid wrapper
+  registration and web allowlist fallback, not host hardened-isolation availability.
+- CI follow-up, local CI-equivalent non-net-admin suite:
+  `uv run pytest -v -m "not requires_cap_net_admin"` passed:
+  `3750 passed, 16 skipped, 1 deselected`.

--- a/docs/analysis/browser-health-gating.md
+++ b/docs/analysis/browser-health-gating.md
@@ -1,0 +1,49 @@
+# Browser Health Gating Worklog
+
+## Scope
+
+Fix the runtime-facing browser availability bug exposed by the Tabelog reservation test: `shisad status` and planner tool registration can advertise browser tools even when `doctor` already reports the configured browser command as unusable.
+
+## Pre-Analysis
+
+- Product contract: missing or misconfigured integrations must produce actionable diagnostics and must not dead-end normal user tasks.
+- Runtime hotspot: `DaemonServices.build()` registers planner-visible browser tools from `browser_enabled`, while `BrowserToolkit.doctor_status()` can independently report `misconfigured`.
+- Expected behavior: browser tools are planner-visible only when the browser runtime health check is `ok`; otherwise web/search/fetch tools remain available and status surfaces the browser diagnostic.
+- Validation scope: targeted daemon-service/tool-registry tests, browser toolkit tests, static checks, first-principles behavioral gates, and live runner doctor/status evidence.
+- Cleanup backlog: no touched-area cleanup or TODO backlog docs found under `docs/`.
+
+## Validation Log
+
+- Test-first check before implementation:
+  `uv run pytest tests/unit/test_daemon_services.py -k 'browser_registry_falls_back_to_web_allowlist or misconfigured_runtime_suppresses_browser_tools' -q`
+  failed as expected with `AttributeError: 'DaemonServices' object has no attribute 'browser_status'`.
+- Focused daemon-service regression:
+  `uv run pytest tests/unit/test_daemon_services.py -k 'browser_registry_falls_back_to_web_allowlist or misconfigured_runtime_suppresses_browser_tools' -q`
+  passed: `2 passed, 54 deselected`.
+- Browser and daemon-service unit coverage:
+  `uv run pytest tests/unit/test_daemon_services.py tests/unit/test_browser_toolkit.py -q`
+  passed: `240 passed`.
+- Static checks:
+  `uv run ruff check src/ tests/ scripts/` passed.
+- Static typing:
+  `uv run mypy src/shisad/` passed: `Success: no issues found in 218 source files`.
+- First-principles behavioral gate:
+  `uv run pytest tests/behavioral/test_first_principles_gates.py -q`
+  passed: `6 passed`.
+- Focused behavioral browser/tool follow-up:
+  `uv run pytest tests/behavioral/test_behavioral_contract.py::test_contract_browser_navigate_executes_and_returns_page tests/behavioral/test_command_chat_pending_actions.py::test_command_chat_explicit_resolution_uses_planner_action_resolve -q`
+  passed: `6 passed`.
+- Full behavioral suite:
+  `uv run pytest tests/behavioral/ -q`
+  passed: `254 passed, 14 skipped`.
+- Live runner verification:
+  `RUNNER_INHERIT_SHISAD_ENV=1 RUNNER_TMUX_SOCKET_NAME=shisad-dev-browser-gate RUNNER_TMUX_SESSION_NAME=shisad-dev-browser-gate SHISAD_DATA_DIR=/tmp/shisad-browser-gate-data SHISAD_SOCKET_PATH=/tmp/shisad-browser-gate.sock SHISAD_POLICY_PATH=/tmp/shisad-browser-gate-policy.yaml bash runner/harness.sh start --no-debug`
+  passed: daemon started on `/tmp/shisad-browser-gate.sock`.
+- Live runner status:
+  `RUNNER_INHERIT_SHISAD_ENV=1 RUNNER_TMUX_SOCKET_NAME=shisad-dev-browser-gate RUNNER_TMUX_SESSION_NAME=shisad-dev-browser-gate SHISAD_DATA_DIR=/tmp/shisad-browser-gate-data SHISAD_SOCKET_PATH=/tmp/shisad-browser-gate.sock SHISAD_POLICY_PATH=/tmp/shisad-browser-gate-policy.yaml bash runner/harness.sh shisad status`
+  passed and reported `executors.browser.runtime.status: misconfigured`,
+  `browser_command_protocol_incompatible`, `executors.browser.tools_available: false`,
+  and no `browser.*` entries in `tools_registered`.
+- Live runner cleanup:
+  `RUNNER_INHERIT_SHISAD_ENV=1 RUNNER_TMUX_SOCKET_NAME=shisad-dev-browser-gate RUNNER_TMUX_SESSION_NAME=shisad-dev-browser-gate SHISAD_DATA_DIR=/tmp/shisad-browser-gate-data SHISAD_SOCKET_PATH=/tmp/shisad-browser-gate.sock SHISAD_POLICY_PATH=/tmp/shisad-browser-gate-policy.yaml bash runner/harness.sh stop`
+  passed: daemon stop requested.

--- a/docs/analysis/browser-health-gating.md
+++ b/docs/analysis/browser-health-gating.md
@@ -47,3 +47,14 @@ Fix the runtime-facing browser availability bug exposed by the Tabelog reservati
 - Live runner cleanup:
   `RUNNER_INHERIT_SHISAD_ENV=1 RUNNER_TMUX_SOCKET_NAME=shisad-dev-browser-gate RUNNER_TMUX_SESSION_NAME=shisad-dev-browser-gate SHISAD_DATA_DIR=/tmp/shisad-browser-gate-data SHISAD_SOCKET_PATH=/tmp/shisad-browser-gate.sock SHISAD_POLICY_PATH=/tmp/shisad-browser-gate-policy.yaml bash runner/harness.sh stop`
   passed: daemon stop requested.
+- CI follow-up, daemon site guard:
+  `uv run python scripts/test_daemon_site_guard.py --baseline tests/fixtures/daemon_site_baseline.json --tests-root tests`
+  initially failed because the new regression added a direct `DaemonServices.build`
+  call site in `tests/unit/test_daemon_services.py` (`28 > baseline 27`);
+  after routing the browser registry tests through a shared helper it passed:
+  `DaemonServices.build: 45`, `run_daemon: 100`.
+- CI follow-up, focused browser registry regression:
+  `uv run pytest tests/unit/test_daemon_services.py -k 'browser_registry_falls_back_to_web_allowlist or misconfigured_runtime_suppresses_browser_tools' -q`
+  passed: `2 passed, 54 deselected`.
+- CI follow-up, static checks:
+  `uv run ruff check src/ tests/ scripts/` passed.

--- a/src/shisad/daemon/handlers/_impl_admin.py
+++ b/src/shisad/daemon/handlers/_impl_admin.py
@@ -1559,7 +1559,14 @@ class AdminImplMixin(HandlerMixinBase):
             "executors": {
                 "sandbox_backends": [item.value for item in SandboxType],
                 "connect_path": self._sandbox.connect_path_status(),
-                "browser": self._browser_sandbox.policy.model_dump(mode="json"),
+                "browser": {
+                    **self._browser_sandbox.policy.model_dump(mode="json"),
+                    "runtime": dict(getattr(self._services, "browser_status", {})),
+                    "tools_available": any(
+                        str(tool.name).startswith("browser.")
+                        for tool in self._registry.list_tools()
+                    ),
+                },
             },
             "selfmod": self._selfmod_manager.status(),
             "realitycheck": self._realitycheck_toolkit.doctor_status(),

--- a/src/shisad/daemon/services.py
+++ b/src/shisad/daemon/services.py
@@ -267,6 +267,72 @@ def _build_browser_sandbox(
     )
 
 
+def _browser_toolkit_kwargs(
+    *,
+    config: DaemonConfig,
+    sandbox: SandboxOrchestrator,
+    browser_sandbox: Any,
+    allowed_domains: list[str],
+) -> dict[str, Any]:
+    return {
+        "enabled": bool(config.browser_enabled),
+        "command": config.browser_command,
+        "session_root": config.data_dir / "browser",
+        "allowed_domains": list(allowed_domains),
+        "timeout_seconds": config.browser_timeout_seconds,
+        "require_hardened_isolation": bool(config.browser_require_hardened_isolation),
+        "max_read_bytes": config.browser_max_read_bytes,
+        "sandbox_runner": sandbox,
+        "browser_sandbox": browser_sandbox,
+    }
+
+
+async def _browser_startup_status(
+    *,
+    config: DaemonConfig,
+    sandbox: SandboxOrchestrator,
+    browser_sandbox: Any,
+    allowed_domains: list[str],
+) -> dict[str, Any]:
+    if not config.browser_enabled:
+        return {
+            "enabled": False,
+            "command": "",
+            "allowed_domains": list(allowed_domains),
+            "require_hardened_isolation": bool(config.browser_require_hardened_isolation),
+            "problems": [],
+            "protocol": {"supported": False, "probe": "", "reason": ""},
+            "status": "disabled",
+        }
+    try:
+        from shisad.executors.browser import BrowserToolkit
+
+        toolkit = BrowserToolkit(
+            **_browser_toolkit_kwargs(
+                config=config,
+                sandbox=sandbox,
+                browser_sandbox=browser_sandbox,
+                allowed_domains=allowed_domains,
+            )
+        )
+        return dict(await toolkit.doctor_status())
+    except Exception:
+        logger.exception("Browser startup health check failed")
+        return {
+            "enabled": True,
+            "command": config.browser_command,
+            "allowed_domains": list(allowed_domains),
+            "require_hardened_isolation": bool(config.browser_require_hardened_isolation),
+            "problems": ["browser_doctor_failed"],
+            "protocol": {"supported": False, "probe": "", "reason": "browser_doctor_failed"},
+            "status": "misconfigured",
+        }
+
+
+def _browser_surface_available(browser_status: dict[str, Any]) -> bool:
+    return bool(browser_status.get("enabled")) and browser_status.get("status") == "ok"
+
+
 def _realitycheck_disabled_status(
     *,
     config: DaemonConfig,
@@ -439,6 +505,7 @@ class DaemonServices:
     msgvault_toolkit: MsgvaultToolkit
     realitycheck_toolkit: RealityCheckToolkit
     realitycheck_status: dict[str, Any]
+    browser_status: dict[str, Any]
     lockdown_manager: LockdownManager
     rate_limiter: RateLimiter
     monitor: ActionMonitor
@@ -807,10 +874,23 @@ class DaemonServices:
                 browser_destinations = [
                     item.strip() for item in config.web_allowed_domains if item.strip()
                 ]
+            browser_status = await _browser_startup_status(
+                config=config,
+                sandbox=sandbox,
+                browser_sandbox=browser_sandbox,
+                allowed_domains=browser_destinations,
+            )
+            browser_surface_enabled = _browser_surface_available(browser_status)
+            if config.browser_enabled and not browser_surface_enabled:
+                logger.warning(
+                    "Browser tools not registered because browser runtime is %s: %s",
+                    browser_status.get("status", "unknown"),
+                    ", ".join(str(item) for item in browser_status.get("problems", [])) or "none",
+                )
             registry, alarm_tool = _build_tool_registry(
                 event_bus,
                 web_search_destination=search_backend_destination,
-                browser_surface_enabled=bool(config.browser_enabled),
+                browser_surface_enabled=browser_surface_enabled,
                 browser_destinations=browser_destinations,
                 realitycheck_surface_enabled=bool(
                     realitycheck_status.get("surface_enabled", False)
@@ -925,6 +1005,7 @@ class DaemonServices:
                 msgvault_toolkit=msgvault_toolkit,
                 realitycheck_toolkit=realitycheck_toolkit,
                 realitycheck_status=realitycheck_status,
+                browser_status=browser_status,
                 lockdown_manager=lockdown_manager,
                 rate_limiter=rate_limiter,
                 monitor=monitor,

--- a/tests/behavioral/test_behavioral_contract.py
+++ b/tests/behavioral/test_behavioral_contract.py
@@ -14,6 +14,7 @@ import asyncio
 import json
 import os
 import re
+import shutil
 import sqlite3
 import struct
 import subprocess
@@ -1033,6 +1034,14 @@ class ContractHarness:
     browser_base_url: str
 
 
+def _executable_fake_browser_command(tmp_path: Path) -> str:
+    source = Path(__file__).resolve().parents[1] / "fixtures" / "fake_playwright_cli.py"
+    target = tmp_path / "fake_playwright_cli.py"
+    shutil.copy2(source, target)
+    target.chmod(0o755)
+    return str(target)
+
+
 @asynccontextmanager
 async def _contract_harness_context(
     tmp_path: Path,
@@ -1096,10 +1105,7 @@ async def _contract_harness_context(
                 "browser_enabled": web_search_backend_configured
                 if browser_enabled is None
                 else browser_enabled,
-                "browser_command": (
-                    f"{sys.executable} "
-                    f"{Path(__file__).resolve().parents[1] / 'fixtures' / 'fake_playwright_cli.py'}"
-                ),
+                "browser_command": _executable_fake_browser_command(tmp_path),
                 "browser_allowed_domains": browser_allowed_domains or ["127.0.0.1", "localhost"],
                 "browser_require_hardened_isolation": False,
                 "assistant_fs_roots": [workspace_root],

--- a/tests/fixtures/fake_playwright_cli.py
+++ b/tests/fixtures/fake_playwright_cli.py
@@ -929,6 +929,13 @@ def main(argv: list[str] | None = None) -> int:
         raise SystemExit("command required")
 
     command = args.pop(0)
+    if command == "--shisad-browser-wrapper-version":
+        print("shisad-browser-wrapper 2")
+        return 0
+    if command == "--shisad-browser-wrapper-doctor":
+        print("shisad-browser-wrapper doctor ok")
+        return 0
+
     cwd = Path.cwd()
     state = _load_state(cwd, session)
 

--- a/tests/unit/test_daemon_services.py
+++ b/tests/unit/test_daemon_services.py
@@ -49,6 +49,27 @@ from shisad.skills.artifacts import ArtifactState
 from shisad.skills.manager import InstalledSkill
 
 
+def _write_browser_wrapper(path) -> None:
+    path.write_text(
+        "\n".join(
+            [
+                "#!/usr/bin/env python3",
+                "import sys",
+                "if '--shisad-browser-wrapper-version' in sys.argv:",
+                "    print('shisad-browser-wrapper 2')",
+                "    raise SystemExit(0)",
+                "if '--shisad-browser-wrapper-doctor' in sys.argv:",
+                "    print('shisad-browser-wrapper doctor ok')",
+                "    raise SystemExit(0)",
+                "raise SystemExit(1)",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+
+
 def test_u8_daemon_runner_import_defers_disabled_backend_modules() -> None:
     code = textwrap.dedent(
         """
@@ -1566,20 +1587,51 @@ def test_daemon_config_preserves_ipv6_loopback_approval_origin(tmp_path) -> None
 @pytest.mark.asyncio
 async def test_m6_daemon_services_browser_registry_falls_back_to_web_allowlist(
     tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _clear_remote_provider_env(monkeypatch)
+    wrapper = tmp_path / "shisad-browser-wrapper"
+    _write_browser_wrapper(wrapper)
     config = DaemonConfig(
         data_dir=tmp_path / "data",
         socket_path=tmp_path / "control.sock",
         policy_path=tmp_path / "policy.yaml",
         browser_enabled=True,
+        browser_command=str(wrapper),
         web_allowed_domains=["localhost"],
         browser_allowed_domains=[],
     )
     services = await DaemonServices.build(config)
     try:
+        assert services.browser_status["status"] == "ok"
         navigate_tool = services.registry.get_tool(ToolName("browser.navigate"))
         assert navigate_tool is not None
         assert navigate_tool.destinations == ["localhost"]
+    finally:
+        await services.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_gh_browser_misconfigured_runtime_suppresses_browser_tools(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_remote_provider_env(monkeypatch)
+    config = DaemonConfig(
+        data_dir=tmp_path / "data",
+        socket_path=tmp_path / "control.sock",
+        policy_path=tmp_path / "policy.yaml",
+        browser_enabled=True,
+        browser_command="",
+        web_allowed_domains=["localhost"],
+    )
+
+    services = await DaemonServices.build(config)
+    try:
+        assert services.browser_status["status"] == "misconfigured"
+        assert "browser_command_unconfigured" in services.browser_status["problems"]
+        assert services.registry.get_tool(ToolName("browser.navigate")) is None
+        assert services.registry.get_tool(ToolName("browser.read_page")) is None
     finally:
         await services.shutdown()
 

--- a/tests/unit/test_daemon_services.py
+++ b/tests/unit/test_daemon_services.py
@@ -1602,6 +1602,7 @@ async def test_m6_daemon_services_browser_registry_falls_back_to_web_allowlist(
         policy_path=tmp_path / "policy.yaml",
         browser_enabled=True,
         browser_command=str(wrapper),
+        browser_require_hardened_isolation=False,
         web_allowed_domains=["localhost"],
         browser_allowed_domains=[],
     )

--- a/tests/unit/test_daemon_services.py
+++ b/tests/unit/test_daemon_services.py
@@ -1584,6 +1584,10 @@ def test_daemon_config_preserves_ipv6_loopback_approval_origin(tmp_path) -> None
     assert config.approval_bind_port == 8787
 
 
+async def _build_browser_registry_services(config: DaemonConfig) -> DaemonServices:
+    return await DaemonServices.build(config)
+
+
 @pytest.mark.asyncio
 async def test_m6_daemon_services_browser_registry_falls_back_to_web_allowlist(
     tmp_path,
@@ -1601,7 +1605,7 @@ async def test_m6_daemon_services_browser_registry_falls_back_to_web_allowlist(
         web_allowed_domains=["localhost"],
         browser_allowed_domains=[],
     )
-    services = await DaemonServices.build(config)
+    services = await _build_browser_registry_services(config)
     try:
         assert services.browser_status["status"] == "ok"
         navigate_tool = services.registry.get_tool(ToolName("browser.navigate"))
@@ -1626,7 +1630,7 @@ async def test_gh_browser_misconfigured_runtime_suppresses_browser_tools(
         web_allowed_domains=["localhost"],
     )
 
-    services = await DaemonServices.build(config)
+    services = await _build_browser_registry_services(config)
     try:
         assert services.browser_status["status"] == "misconfigured"
         assert "browser_command_unconfigured" in services.browser_status["problems"]


### PR DESCRIPTION
## Summary

Browser tools were planner-visible whenever `browser_enabled` was true, even if the browser doctor already reported that the configured browser command was unusable. This caused the agent to try browser navigation with an unavailable runtime instead of degrading to the still-available web/search/fetch tools.

This PR gates browser tool registration on the startup browser health check and exposes that runtime status in `shisad status` so misconfiguration is visible without advertising unusable tools.

Related to #24, #25, and #26.

## Changes

- Run browser doctor status during `DaemonServices.build()` before registering planner-visible browser tools.
- Register `browser.*` tools only when browser runtime status is `ok`; otherwise keep non-browser tools available.
- Surface browser runtime health and `tools_available` in daemon status.
- Add daemon-service regression coverage for misconfigured browser commands suppressing browser tools.
- Keep the new browser regression behind a shared daemon-build helper so the daemon site guard baseline does not grow.
- Make the browser registry/web allowlist fallback test independent of hosted-runner hardened-isolation support.
- Update the fake Playwright fixture and behavioral harness so valid test browser runtimes pass the wrapper protocol check.
- Record worklog and validation evidence in `docs/analysis/browser-health-gating.md`.

## Validation

- `uv run pytest tests/unit/test_daemon_services.py -k 'browser_registry_falls_back_to_web_allowlist or misconfigured_runtime_suppresses_browser_tools' -q` -> `2 passed, 54 deselected`
- `uv run pytest tests/unit/test_daemon_services.py tests/unit/test_browser_toolkit.py -q` -> `240 passed`
- `uv run python scripts/test_daemon_site_guard.py --baseline tests/fixtures/daemon_site_baseline.json --tests-root tests` -> passed, `DaemonServices.build: 45`, `run_daemon: 100`
- `uv run ruff check src/ tests/ scripts/` -> passed
- `uv run mypy src/shisad/` -> passed
- `uv run pytest -v -m "not requires_cap_net_admin"` -> `3750 passed, 16 skipped, 1 deselected`
- `uv run pytest tests/behavioral/test_first_principles_gates.py -q` -> `6 passed`
- `uv run pytest tests/behavioral/test_behavioral_contract.py::test_contract_browser_navigate_executes_and_returns_page tests/behavioral/test_command_chat_pending_actions.py::test_command_chat_explicit_resolution_uses_planner_action_resolve -q` -> `6 passed`
- `uv run pytest tests/behavioral/ -q` -> `254 passed, 14 skipped`
- Live runner: isolated daemon started, `shisad status` reported `browser_command_protocol_incompatible`, `executors.browser.tools_available: false`, and no `browser.*` entries in `tools_registered`; daemon stopped cleanly.