### PR TITLE
[codex] Propagate browser failure details

### DIFF
--- a/src/shisad/cli/main.py
+++ b/src/shisad/cli/main.py
@@ -2049,6 +2049,29 @@ def _preview_cli_text(value: object, *, max_chars: int = 1600, max_lines: int = 
     return preview
 
 
+def _tool_error_detail_line(payload: dict[str, Any], *, max_chars: int = 240) -> str:
+    details = payload.get("details")
+    if not isinstance(details, dict):
+        return ""
+    raw_detail = ""
+    for key in ("stderr", "stdout"):
+        value = details.get(key)
+        if isinstance(value, str) and value.strip():
+            raw_detail = value
+            break
+    if not raw_detail and details.get("exit_code") not in ("", None):
+        raw_detail = f"exit_code={details.get('exit_code')}"
+    text = sanitize_terminal_text(raw_detail).strip()
+    if not text:
+        return ""
+    first_line = text.splitlines()[0].strip()
+    if len(first_line) > max_chars:
+        first_line = f"{first_line[: max_chars - 3].rstrip()}..."
+    if not first_line:
+        return ""
+    return f"  detail: {sanitize_terminal_field(first_line)}"
+
+
 def _render_confirmed_tool_output(record: dict[str, Any]) -> list[str]:
     tool_name = sanitize_terminal_field(str(record.get("tool_name", "")).strip() or "tool")
     payload = record.get("payload")
@@ -2111,7 +2134,12 @@ def _render_confirmed_tool_output(record: dict[str, Any]) -> list[str]:
         value = payload.get(key)
         if value not in ("", None, [], {}):
             summary_parts.append(f"{key}={sanitize_terminal_field(str(value))}")
-    return [" ".join(summary_parts)]
+    lines = [" ".join(summary_parts)]
+    if error:
+        detail_line = _tool_error_detail_line(payload)
+        if detail_line:
+            lines.append(detail_line)
+    return lines
 
 
 def _render_action_confirm_result(result: ActionConfirmResult) -> str:

--- a/src/shisad/core/events.py
+++ b/src/shisad/core/events.py
@@ -221,6 +221,7 @@ class ToolExecuted(BaseEvent):
     tool_name: ToolName
     success: bool = True
     error: str = ""
+    details: dict[str, Any] = Field(default_factory=dict)
     approval_session_id: str = ""
     approval_task_envelope_id: str = ""
     approval_confirmation_id: str = ""

--- a/src/shisad/daemon/handlers/_tool_exec_helpers.py
+++ b/src/shisad/daemon/handlers/_tool_exec_helpers.py
@@ -30,6 +30,21 @@ def _payload_taint_labels(payload: Mapping[str, Any]) -> set[TaintLabel]:
     return labels
 
 
+def _browser_audit_details(tool_name: ToolName, payload: Mapping[str, Any]) -> dict[str, Any]:
+    if not str(tool_name).startswith("browser."):
+        return {}
+    details = payload.get("details")
+    if not isinstance(details, Mapping):
+        return {}
+    safe_details: dict[str, Any] = {}
+    for key, value in details.items():
+        if not isinstance(key, str):
+            continue
+        if isinstance(value, str | int | float | bool) or value is None:
+            safe_details[key] = value
+    return safe_details
+
+
 async def execute_structured_tool(
     *,
     session_id: SessionId,
@@ -45,13 +60,15 @@ async def execute_structured_tool(
 ) -> StructuredToolExecutionResult:
     success = bool(payload.get("ok", False))
     event_fields = dict(approval_event_fields or {})
+    error = "" if success else str(payload.get("error", default_error))
+    details = {} if success else _browser_audit_details(tool_name, payload)
     if not success:
         await emit_event(
             ToolRejected(
                 session_id=session_id,
                 actor=actor,
                 tool_name=tool_name,
-                reason=str(payload.get("error", default_error)),
+                reason=error,
                 **event_fields,
             )
         )
@@ -61,6 +78,8 @@ async def execute_structured_tool(
             actor=actor,
             tool_name=tool_name,
             success=success,
+            error=error,
+            details=details,
             **event_fields,
         )
     )

--- a/tests/unit/test_cli_main.py
+++ b/tests/unit/test_cli_main.py
@@ -4225,6 +4225,33 @@ def test_action_confirm_renderer_includes_web_fetch_error() -> None:
     assert lines == ["web.fetch fetched https://example.invalid/ failed: network_unavailable."]
 
 
+def test_action_confirm_renderer_includes_browser_failure_detail() -> None:
+    lines = cli_main._render_confirmed_tool_output(
+        {
+            "tool_name": "browser.navigate",
+            "success": False,
+            "payload": {
+                "ok": False,
+                "error": "browser_subprocess_failed",
+                "details": {
+                    "reason": "browser_subprocess_failed",
+                    "stage": "subprocess",
+                    "exit_code": 17,
+                    "stderr": (
+                        "RangeError: WebAssembly.instantiate(): Out of memory\n"
+                        "second line should stay hidden"
+                    ),
+                },
+            },
+        }
+    )
+
+    assert lines == [
+        "browser.navigate: completed ok=False. error=browser_subprocess_failed",
+        "  detail: RangeError: WebAssembly.instantiate(): Out of memory",
+    ]
+
+
 def test_action_confirm_json_flag_preserves_machine_readable_output(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/test_tool_exec_helpers.py
+++ b/tests/unit/test_tool_exec_helpers.py
@@ -77,6 +77,46 @@ async def test_execute_structured_tool_rejection_emits_rejected_then_executed() 
 
 
 @pytest.mark.asyncio
+async def test_execute_structured_tool_failure_emits_error_and_details_for_audit() -> None:
+    emitted: list[object] = []
+
+    async def _emit(event: object) -> None:
+        emitted.append(event)
+
+    await execute_structured_tool(
+        session_id=SessionId("s1"),
+        tool_name=ToolName("browser.navigate"),
+        payload={
+            "ok": False,
+            "error": "browser_subprocess_failed",
+            "details": {
+                "reason": "browser_subprocess_failed",
+                "stage": "subprocess",
+                "exit_code": 17,
+                "stderr": "failed to read [path] SHISAD_API_KEY=[redacted]",
+            },
+        },
+        default_error="browser_navigate_failed",
+        actor="tool_runtime",
+        emit_event=_emit,
+        record_execution=lambda _success: None,
+        sanitize_output=lambda raw: raw,
+        taint_labels={TaintLabel.UNTRUSTED},
+    )
+
+    executed = emitted[1]
+    assert isinstance(executed, ToolExecuted)
+    assert executed.success is False
+    assert executed.error == "browser_subprocess_failed"
+    assert executed.details == {
+        "reason": "browser_subprocess_failed",
+        "stage": "subprocess",
+        "exit_code": 17,
+        "stderr": "failed to read [path] SHISAD_API_KEY=[redacted]",
+    }
+
+
+@pytest.mark.asyncio
 async def test_execute_structured_tool_uses_default_error_when_missing() -> None:
     emitted: list[object] = []
 


### PR DESCRIPTION
Refs #45

## Summary
- Show sanitized browser subprocess failure details in CLI action-confirm output.
- Preserve failed structured tool errors and browser failure details in ToolExecuted audit events.

## Root Cause
The browser toolkit already returned sanitized failure details, but downstream CLI rendering and audit event emission dropped them.

## Validation
- `uv run pytest tests/unit/test_cli_main.py tests/unit/test_tool_exec_helpers.py tests/unit/test_browser_toolkit.py::test_gh26_browser_toolkit_subprocess_failure_sanitizes_details -q`
- `uv run ruff check src/ tests/ scripts/`
- `uv run mypy src/shisad/`
- `git diff --check`