### PR TITLE
fix: gate browser tools on runtime health

### DIFF
--- a/docs/analysis/browser-health-gating.md
+++ b/docs/analysis/browser-health-gating.md
@@ -58,3 +58,13 @@ Fix the runtime-facing browser availability bug exposed by the Tabelog reservati
   passed: `2 passed, 54 deselected`.
 - CI follow-up, static checks:
   `uv run ruff check src/ tests/ scripts/` passed.
+- CI follow-up, GitHub hosted runner failure:
+  run `26094226652` failed in `security-runtime` and `lint-and-test (3.12)`
+  because `tests/unit/test_daemon_services.py::test_m6_daemon_services_browser_registry_falls_back_to_web_allowlist`
+  expected browser status `ok` while the hosted runner reported
+  `browser_runtime_isolation_unavailable`. The test was updated to set
+  `browser_require_hardened_isolation=False` because it covers valid wrapper
+  registration and web allowlist fallback, not host hardened-isolation availability.
+- CI follow-up, local CI-equivalent non-net-admin suite:
+  `uv run pytest -v -m "not requires_cap_net_admin"` passed:
+  `3750 passed, 16 skipped, 1 deselected`.

--- a/docs/analysis/browser-health-gating.md
+++ b/docs/analysis/browser-health-gating.md
@@ -1,0 +1,49 @@
+# Browser Health Gating Worklog
+
+## Scope
+
+Fix the runtime-facing browser availability bug exposed by the Tabelog reservation test: `shisad status` and planner tool registration can advertise browser tools even when `doctor` already reports the configured browser command as unusable.
+
+## Pre-Analysis
+
+- Product contract: missing or misconfigured integrations must produce actionable diagnostics and must not dead-end normal user tasks.
+- Runtime hotspot: `DaemonServices.build()` registers planner-visible browser tools from `browser_enabled`, while `BrowserToolkit.doctor_status()` can independently report `misconfigured`.
+- Expected behavior: browser tools are planner-visible only when the browser runtime health check is `ok`; otherwise web/search/fetch tools remain available and status surfaces the browser diagnostic.
+- Validation scope: targeted daemon-service/tool-registry tests, browser toolkit tests, static checks, first-principles behavioral gates, and live runner doctor/status evidence.
+- Cleanup backlog: no touched-area cleanup or TODO backlog docs found under `docs/`.
+
+## Validation Log
+
+- Test-first check before implementation:
+  `uv run pytest tests/unit/test_daemon_services.py -k 'browser_registry_falls_back_to_web_allowlist or misconfigured_runtime_suppresses_browser_tools' -q`
+  failed as expected with `AttributeError: 'DaemonServices' object has no attribute 'browser_status'`.
+- Focused daemon-service regression:
+  `uv run pytest tests/unit/test_daemon_services.py -k 'browser_registry_falls_back_to_web_allowlist or misconfigured_runtime_suppresses_browser_tools' -q`
+  passed: `2 passed, 54 deselected`.
+- Browser and daemon-service unit coverage:
+  `uv run pytest tests/unit/test_daemon_services.py tests/unit/test_browser_toolkit.py -q`
+  passed: `240 passed`.
+- Static checks:
+  `uv run ruff check src/ tests/ scripts/` passed.
+- Static typing:
+  `uv run mypy src/shisad/` passed: `Success: no issues found in 218 source files`.
+- First-principles behavioral gate:
+  `uv run pytest tests/behavioral/test_first_principles_gates.py -q`
+  passed: `6 passed`.
+- Focused behavioral browser/tool follow-up:
+  `uv run pytest tests/behavioral/test_behavioral_contract.py::test_contract_browser_navigate_executes_and_returns_page tests/behavioral/test_command_chat_pending_actions.py::test_command_chat_explicit_resolution_uses_planner_action_resolve -q`
+  passed: `6 passed`.
+- Full behavioral suite:
+  `uv run pytest tests/behavioral/ -q`
+  passed: `254 passed, 14 skipped`.
+- Live runner verification:
+  `RUNNER_INHERIT_SHISAD_ENV=1 RUNNER_TMUX_SOCKET_NAME=shisad-dev-browser-gate RUNNER_TMUX_SESSION_NAME=shisad-dev-browser-gate SHISAD_DATA_DIR=/tmp/shisad-browser-gate-data SHISAD_SOCKET_PATH=/tmp/shisad-browser-gate.sock SHISAD_POLICY_PATH=/tmp/shisad-browser-gate-policy.yaml bash runner/harness.sh start --no-debug`
+  passed: daemon started on `/tmp/shisad-browser-gate.sock`.
+- Live runner status:
+  `RUNNER_INHERIT_SHISAD_ENV=1 RUNNER_TMUX_SOCKET_NAME=shisad-dev-browser-gate RUNNER_TMUX_SESSION_NAME=shisad-dev-browser-gate SHISAD_DATA_DIR=/tmp/shisad-browser-gate-data SHISAD_SOCKET_PATH=/tmp/shisad-browser-gate.sock SHISAD_POLICY_PATH=/tmp/shisad-browser-gate-policy.yaml bash runner/harness.sh shisad status`
+  passed and reported `executors.browser.runtime.status: misconfigured`,
+  `browser_command_protocol_incompatible`, `executors.browser.tools_available: false`,
+  and no `browser.*` entries in `tools_registered`.
+- Live runner cleanup:
+  `RUNNER_INHERIT_SHISAD_ENV=1 RUNNER_TMUX_SOCKET_NAME=shisad-dev-browser-gate RUNNER_TMUX_SESSION_NAME=shisad-dev-browser-gate SHISAD_DATA_DIR=/tmp/shisad-browser-gate-data SHISAD_SOCKET_PATH=/tmp/shisad-browser-gate.sock SHISAD_POLICY_PATH=/tmp/shisad-browser-gate-policy.yaml bash runner/harness.sh stop`
+  passed: daemon stop requested.

--- a/docs/analysis/browser-health-gating.md
+++ b/docs/analysis/browser-health-gating.md
@@ -47,3 +47,14 @@ Fix the runtime-facing browser availability bug exposed by the Tabelog reservati
 - Live runner cleanup:
   `RUNNER_INHERIT_SHISAD_ENV=1 RUNNER_TMUX_SOCKET_NAME=shisad-dev-browser-gate RUNNER_TMUX_SESSION_NAME=shisad-dev-browser-gate SHISAD_DATA_DIR=/tmp/shisad-browser-gate-data SHISAD_SOCKET_PATH=/tmp/shisad-browser-gate.sock SHISAD_POLICY_PATH=/tmp/shisad-browser-gate-policy.yaml bash runner/harness.sh stop`
   passed: daemon stop requested.
+- CI follow-up, daemon site guard:
+  `uv run python scripts/test_daemon_site_guard.py --baseline tests/fixtures/daemon_site_baseline.json --tests-root tests`
+  initially failed because the new regression added a direct `DaemonServices.build`
+  call site in `tests/unit/test_daemon_services.py` (`28 > baseline 27`);
+  after routing the browser registry tests through a shared helper it passed:
+  `DaemonServices.build: 45`, `run_daemon: 100`.
+- CI follow-up, focused browser registry regression:
+  `uv run pytest tests/unit/test_daemon_services.py -k 'browser_registry_falls_back_to_web_allowlist or misconfigured_runtime_suppresses_browser_tools' -q`
+  passed: `2 passed, 54 deselected`.
+- CI follow-up, static checks:
+  `uv run ruff check src/ tests/ scripts/` passed.

--- a/src/shisad/daemon/handlers/_impl.py
+++ b/src/shisad/daemon/handlers/_impl.py
@@ -1316,6 +1316,7 @@ class ApprovedToolExecutionResult:
     checkpoint_id: str | None = None
     tool_output: ToolOutputRecord | None = None
     sandbox_result: SandboxResult | None = None
+    error: str = ""
 
 
 class HandlerImplementation(
@@ -2249,7 +2250,11 @@ class HandlerImplementation(
             exit_code=0 if success else 1,
             stdout=tool_output.content if tool_output is not None else "",
             stderr="",
-            reason="" if success else self._structured_tool_reason(tool_output),
+            reason=(
+                ""
+                if success
+                else self._structured_tool_reason(tool_output) or execution.error
+            ),
             checkpoint_id=execution.checkpoint_id or "",
             origin=origin.model_dump(mode="json"),
         )
@@ -3375,7 +3380,7 @@ class HandlerImplementation(
     ) -> ApprovedToolExecutionResult:
         session = self._session_manager.get(sid)
         if session is None:
-            return ApprovedToolExecutionResult(success=False)
+            return ApprovedToolExecutionResult(success=False, error="session_missing")
 
         tool_name = ToolName(canonical_tool_name(str(tool_name), warn_on_alias=False))
         origin = self._origin_for(
@@ -3459,6 +3464,7 @@ class HandlerImplementation(
             return ApprovedToolExecutionResult(
                 success=False,
                 checkpoint_id=checkpoint_id,
+                error=suppressed_browser_reason,
                 tool_output=HandlerImplementation._with_tool_output_ingress(
                     self,
                     session=session,
@@ -3916,12 +3922,23 @@ class HandlerImplementation(
             )
 
         if tool is None:
+            tool_unavailable_reason = "tool_unavailable"
+            await self._event_bus.publish(
+                ToolRejected(
+                    session_id=sid,
+                    actor="tool_runtime",
+                    tool_name=tool_name,
+                    reason=tool_unavailable_reason,
+                    **approval_event_fields,
+                )
+            )
             await self._event_bus.publish(
                 ToolExecuted(
                     session_id=sid,
                     actor="tool_runtime",
                     tool_name=tool_name,
                     success=False,
+                    error=tool_unavailable_reason,
                     **approval_event_fields,
                 )
             )
@@ -3934,6 +3951,7 @@ class HandlerImplementation(
             return ApprovedToolExecutionResult(
                 success=False,
                 checkpoint_id=checkpoint_id,
+                error=tool_unavailable_reason,
             )
 
         sandbox_result = await self._execute_via_sandbox(

--- a/src/shisad/daemon/handlers/_impl.py
+++ b/src/shisad/daemon/handlers/_impl.py
@@ -94,7 +94,10 @@ from shisad.daemon.handlers._impl_assistant import AssistantImplMixin
 from shisad.daemon.handlers._impl_confirmation import ConfirmationImplMixin
 from shisad.daemon.handlers._impl_dashboard import DashboardImplMixin
 from shisad.daemon.handlers._impl_memory import MemoryImplMixin
-from shisad.daemon.handlers._impl_session import SessionImplMixin
+from shisad.daemon.handlers._impl_session import (
+    SessionImplMixin,
+    _browser_runtime_unavailable_rejection_reason,
+)
 from shisad.daemon.handlers._impl_skills import SkillsImplMixin
 from shisad.daemon.handlers._impl_tasks import TasksImplMixin
 from shisad.daemon.handlers._impl_tool_execution import (
@@ -3422,6 +3425,41 @@ class HandlerImplementation(
                 **approval_event_fields,
             )
         )
+
+        suppressed_browser_reason = _browser_runtime_unavailable_rejection_reason(
+            getattr(getattr(self, "_services", None), "browser_status", {}),
+            tool_name=tool_name,
+        )
+        if tool is None and suppressed_browser_reason:
+            await self._event_bus.publish(
+                ToolRejected(
+                    session_id=sid,
+                    actor="tool_runtime",
+                    tool_name=tool_name,
+                    reason=suppressed_browser_reason,
+                    **approval_event_fields,
+                )
+            )
+            await self._event_bus.publish(
+                ToolExecuted(
+                    session_id=sid,
+                    actor="tool_runtime",
+                    tool_name=tool_name,
+                    success=False,
+                    error=suppressed_browser_reason,
+                    **approval_event_fields,
+                )
+            )
+            await _call_control_plane(
+                self,
+                "record_execution",
+                action=executed_action,
+                success=False,
+            )
+            return ApprovedToolExecutionResult(
+                success=False,
+                checkpoint_id=checkpoint_id,
+            )
 
         if tool_name == "report_anomaly":
             payload = AnomalyReportInput.model_validate(arguments)

--- a/src/shisad/daemon/handlers/_impl.py
+++ b/src/shisad/daemon/handlers/_impl.py
@@ -3459,6 +3459,25 @@ class HandlerImplementation(
             return ApprovedToolExecutionResult(
                 success=False,
                 checkpoint_id=checkpoint_id,
+                tool_output=HandlerImplementation._with_tool_output_ingress(
+                    self,
+                    session=session,
+                    tool_output=ToolOutputRecord(
+                        tool_name=str(tool_name),
+                        content=self._sanitize_tool_output_text(
+                            json.dumps(
+                                {
+                                    "ok": False,
+                                    "error": suppressed_browser_reason,
+                                },
+                                ensure_ascii=True,
+                            )
+                        ),
+                        success=False,
+                        taint_labels=label_tool_output(str(tool_name)),
+                        arguments=dict(arguments),
+                    ),
+                ),
             )
 
         if tool_name == "report_anomaly":

--- a/src/shisad/daemon/handlers/_impl.py
+++ b/src/shisad/daemon/handlers/_impl.py
@@ -2224,9 +2224,10 @@ class HandlerImplementation(
         except (TypeError, ValueError):
             return ""
         if isinstance(payload, dict):
-            reason = str(payload.get("error", "")).strip()
-            if reason:
-                return reason
+            for key in ("error", "reason", "status_reason"):
+                reason = str(payload.get(key, "")).strip()
+                if reason:
+                    return reason
         return ""
 
     def _tool_execute_result_from_execution(
@@ -2253,7 +2254,8 @@ class HandlerImplementation(
             reason=(
                 ""
                 if success
-                else self._structured_tool_reason(tool_output) or execution.error
+                else HandlerImplementation._structured_tool_reason(tool_output)
+                or execution.error
             ),
             checkpoint_id=execution.checkpoint_id or "",
             origin=origin.model_dump(mode="json"),

--- a/src/shisad/daemon/handlers/_impl_admin.py
+++ b/src/shisad/daemon/handlers/_impl_admin.py
@@ -1559,7 +1559,14 @@ class AdminImplMixin(HandlerMixinBase):
             "executors": {
                 "sandbox_backends": [item.value for item in SandboxType],
                 "connect_path": self._sandbox.connect_path_status(),
-                "browser": self._browser_sandbox.policy.model_dump(mode="json"),
+                "browser": {
+                    **self._browser_sandbox.policy.model_dump(mode="json"),
+                    "runtime": dict(getattr(self._services, "browser_status", {})),
+                    "tools_available": any(
+                        str(tool.name).startswith("browser.")
+                        for tool in self._registry.list_tools()
+                    ),
+                },
             },
             "selfmod": self._selfmod_manager.status(),
             "realitycheck": self._realitycheck_toolkit.doctor_status(),

--- a/src/shisad/daemon/handlers/_impl_confirmation.py
+++ b/src/shisad/daemon/handlers/_impl_confirmation.py
@@ -130,6 +130,22 @@ def _serialize_confirmed_tool_output(record: Any) -> dict[str, Any]:
     }
 
 
+def _confirmed_execution_failure_reason(record: Any) -> str:
+    if record is None or bool(getattr(record, "success", False)):
+        return ""
+    try:
+        payload = json.loads(str(getattr(record, "content", "")))
+    except json.JSONDecodeError:
+        return ""
+    if not isinstance(payload, dict):
+        return ""
+    for key in ("error", "reason", "status_reason"):
+        reason = str(payload.get(key, "")).strip()
+        if reason:
+            return reason
+    return ""
+
+
 def _confirmed_tool_output_transcript_content(*, tool_name: str, content: str) -> str:
     canonical_name = canonical_tool_name(tool_name, warn_on_alias=False)
     if canonical_name not in _CONFIRMED_TRANSCRIPT_PAGE_TITLE_TOOL_NAMES:
@@ -1774,8 +1790,14 @@ class ConfirmationImplMixin(HandlerMixinBase):
                     )
                 )
         pending.status = "approved" if success else "failed"
+        execution_failure_reason = (
+            "" if success else _confirmed_execution_failure_reason(tool_output)
+        )
         pending.status_reason = (
-            promote_followup_reason or str(params.get("reason", "")).strip() or pending.status
+            promote_followup_reason
+            or execution_failure_reason
+            or str(params.get("reason", "")).strip()
+            or pending.status
         )
         self._sync_task_confirmation_status(pending)
         self._record_task_confirmation_outcome(pending, success=success)

--- a/src/shisad/daemon/handlers/_impl_confirmation.py
+++ b/src/shisad/daemon/handlers/_impl_confirmation.py
@@ -1791,7 +1791,12 @@ class ConfirmationImplMixin(HandlerMixinBase):
                 )
         pending.status = "approved" if success else "failed"
         execution_failure_reason = (
-            "" if success else _confirmed_execution_failure_reason(tool_output)
+            ""
+            if success
+            else (
+                _confirmed_execution_failure_reason(tool_output)
+                or str(getattr(execution_result, "error", "")).strip()
+            )
         )
         pending.status_reason = (
             promote_followup_reason

--- a/src/shisad/daemon/handlers/_impl_session.py
+++ b/src/shisad/daemon/handlers/_impl_session.py
@@ -2324,6 +2324,7 @@ def _build_planner_tool_context(
     capabilities: set[Capability],
     tool_allowlist: set[ToolName] | None,
     trust_level: str,
+    runtime_availability_notes: Sequence[str] = (),
 ) -> str:
     visible_tools = [
         tool for tool in registry_tools if tool_allowlist is None or tool.name in tool_allowlist
@@ -2379,6 +2380,11 @@ def _build_planner_tool_context(
         )
     if alias_note:
         lines.append(alias_note)
+    runtime_notes = [note.strip() for note in runtime_availability_notes if note.strip()]
+    if runtime_notes:
+        lines.append("Runtime availability notes:")
+        for note in runtime_notes:
+            lines.append(f"- {note}")
     if not enabled_tools:
         lines.append("Enabled tools: none")
         if _shows_trusted_tool_context(trust_level) and disabled_tools:
@@ -2421,6 +2427,13 @@ def _build_planner_tool_context(
         )
     lines.append("If no tool is needed, respond conversationally without calling tools.")
     return "\n".join(lines)
+
+
+def _planner_runtime_availability_notes(browser_status: Mapping[str, Any]) -> tuple[str, ...]:
+    browser_note = str(browser_status.get("planner_note") or "").strip()
+    if not browser_note:
+        return ()
+    return (browser_note,)
 
 
 def _planner_manifest_includes_report_anomaly(
@@ -8662,6 +8675,9 @@ class SessionImplMixin(HandlerMixinBase):
             capabilities=effective_caps,
             tool_allowlist=planner_tool_allowlist,
             trust_level=validated.trust_level,
+            runtime_availability_notes=_planner_runtime_availability_notes(
+                getattr(self._services, "browser_status", {})
+            ),
         )
         task_ledger_snapshot = None
         if not zero_context_session:

--- a/src/shisad/daemon/handlers/_impl_session.py
+++ b/src/shisad/daemon/handlers/_impl_session.py
@@ -205,6 +205,16 @@ _POST_TOOL_SYNTHESIS_SUMMARY_MAX_CHARS = 2600
 _POST_TOOL_SYNTHESIS_PRELIMINARY_MAX_CHARS = 2200
 _OUTPUT_URL_RE = re.compile(r"https?://[^\s)>]+")
 _PAGE_TITLE_METADATA_MAX_CHARS = 1600
+_BROWSER_RUNTIME_GATED_TOOL_NAMES = frozenset(
+    {
+        "browser.navigate",
+        "browser.read_page",
+        "browser.screenshot",
+        "browser.click",
+        "browser.type_text",
+        "browser.end_session",
+    }
+)
 
 
 def _is_sensitive_browser_type_text_tool(tool_name: ToolName | str) -> bool:
@@ -4293,14 +4303,30 @@ def _flatten_rejection_reason_codes(reasons: list[str]) -> list[str]:
     return codes
 
 
-def _browser_runtime_unavailable_rejection_reason(browser_status: Mapping[str, Any]) -> str:
+def _browser_runtime_unavailable_rejection_reason(
+    browser_status: Mapping[str, Any],
+    *,
+    tool_name: str | ToolName = "",
+) -> str:
+    if tool_name:
+        canonical_browser_tool_name = canonical_tool_name(str(tool_name), warn_on_alias=False)
+        if canonical_browser_tool_name not in _BROWSER_RUNTIME_GATED_TOOL_NAMES:
+            return ""
     status = str(browser_status.get("status") or "unavailable").strip() or "unavailable"
+    if status == "ok":
+        return ""
+    raw_problems = browser_status.get("problems", [])
+    if not isinstance(raw_problems, list | tuple | set | frozenset):
+        raw_problems = [raw_problems]
     problems = [
         str(item).strip()
-        for item in browser_status.get("problems", [])
+        for item in raw_problems
         if str(item).strip()
     ]
-    reason = problems[0] if problems else "unknown_browser_runtime_problem"
+    if status == "disabled" or browser_status.get("enabled") is False:
+        reason = "browser_disabled"
+    else:
+        reason = problems[0] if problems else "unknown_browser_runtime_problem"
     return f"browser_runtime_unavailable:{status}:{reason}"
 
 
@@ -4331,6 +4357,19 @@ def _blocked_action_feedback(reasons: list[str]) -> str:
         parts = browser_runtime_reason.split(":", 2)
         status = parts[1] if len(parts) > 1 and parts[1] else "unavailable"
         problem = parts[2] if len(parts) > 2 and parts[2] else ""
+        if status == "disabled" or problem == "browser_disabled":
+            return (
+                "I couldn't use browser tools because browser tools are disabled "
+                "in this daemon configuration. I can use web.search/web.fetch when "
+                "search or fetch can satisfy the request."
+            )
+        if problem == "unknown_browser_runtime_problem":
+            return (
+                "I couldn't use browser tools because browser runtime status is "
+                f"{status}. The runtime did not report a specific problem. I can "
+                "use web.search/web.fetch when search or fetch can satisfy the "
+                "request."
+            )
         problem_suffix = f": {problem}" if problem else ""
         return (
             "I couldn't use browser tools because browser runtime status is "
@@ -8705,7 +8744,7 @@ class SessionImplMixin(HandlerMixinBase):
             tool_allowlist=planner_tool_allowlist,
             trust_level=validated.trust_level,
             runtime_availability_notes=_planner_runtime_availability_notes(
-                getattr(self._services, "browser_status", {})
+                getattr(getattr(self, "_services", None), "browser_status", {})
             ),
         )
         task_ledger_snapshot = None
@@ -9479,13 +9518,15 @@ class SessionImplMixin(HandlerMixinBase):
                     ),
                 )
             )
-            if (
-                proposal_tool_name.startswith("browser.")
-                and self._registry.get_tool(canonical_proposal_tool) is None
+            final_reason = ""
+            if proposal_tool_name.startswith("browser.") and (
+                self._registry.get_tool(canonical_proposal_tool) is None
             ):
                 final_reason = _browser_runtime_unavailable_rejection_reason(
-                    getattr(self._services, "browser_status", {})
+                    getattr(self._services, "browser_status", {}),
+                    tool_name=proposal_tool_name,
                 )
+            if final_reason:
                 rejected += 1
                 rejection_reasons_for_user.append(final_reason)
                 public_arguments = _redact_sensitive_browser_public_arguments(

--- a/src/shisad/daemon/handlers/_impl_session.py
+++ b/src/shisad/daemon/handlers/_impl_session.py
@@ -2380,7 +2380,11 @@ def _build_planner_tool_context(
         )
     if alias_note:
         lines.append(alias_note)
-    runtime_notes = [note.strip() for note in runtime_availability_notes if note.strip()]
+    runtime_notes = (
+        [note.strip() for note in runtime_availability_notes if note.strip()]
+        if _shows_trusted_tool_context(trust_level)
+        else []
+    )
     if runtime_notes:
         lines.append("Runtime availability notes:")
         for note in runtime_notes:

--- a/src/shisad/daemon/handlers/_impl_session.py
+++ b/src/shisad/daemon/handlers/_impl_session.py
@@ -4468,6 +4468,8 @@ def _coerce_blocked_action_response_text(
     if rejected <= 0 or pending_confirmation > 0 or executed_tool_outputs > 0:
         return response_text
     codes = _flatten_rejection_reason_codes(rejection_reasons)
+    if any(code.startswith("browser_runtime_unavailable:") for code in codes):
+        return _blocked_action_feedback(rejection_reasons)
     if any(code == "resource:outside_workspace_root" for code in codes):
         return _blocked_action_feedback(rejection_reasons)
     if any(code == "pep:resource_authorization_failed" for code in codes):

--- a/src/shisad/daemon/handlers/_impl_session.py
+++ b/src/shisad/daemon/handlers/_impl_session.py
@@ -4308,6 +4308,8 @@ def _browser_runtime_unavailable_rejection_reason(
     *,
     tool_name: str | ToolName = "",
 ) -> str:
+    if not browser_status:
+        return ""
     if tool_name:
         canonical_browser_tool_name = canonical_tool_name(str(tool_name), warn_on_alias=False)
         if canonical_browser_tool_name not in _BROWSER_RUNTIME_GATED_TOOL_NAMES:

--- a/src/shisad/daemon/handlers/_impl_session.py
+++ b/src/shisad/daemon/handlers/_impl_session.py
@@ -4293,6 +4293,17 @@ def _flatten_rejection_reason_codes(reasons: list[str]) -> list[str]:
     return codes
 
 
+def _browser_runtime_unavailable_rejection_reason(browser_status: Mapping[str, Any]) -> str:
+    status = str(browser_status.get("status") or "unavailable").strip() or "unavailable"
+    problems = [
+        str(item).strip()
+        for item in browser_status.get("problems", [])
+        if str(item).strip()
+    ]
+    reason = problems[0] if problems else "unknown_browser_runtime_problem"
+    return f"browser_runtime_unavailable:{status}:{reason}"
+
+
 def _action_monitor_explanation_from_votes(votes: Sequence[Any]) -> str:
     for vote in votes:
         if str(getattr(vote, "voter", "")) != "ActionMonitorVoter":
@@ -4312,6 +4323,20 @@ def _action_monitor_explanation_from_votes(votes: Sequence[Any]) -> str:
 
 def _blocked_action_feedback(reasons: list[str]) -> str:
     codes = _flatten_rejection_reason_codes(reasons)
+    browser_runtime_reason = next(
+        (code for code in codes if code.startswith("browser_runtime_unavailable:")),
+        "",
+    )
+    if browser_runtime_reason:
+        parts = browser_runtime_reason.split(":", 2)
+        status = parts[1] if len(parts) > 1 and parts[1] else "unavailable"
+        problem = parts[2] if len(parts) > 2 and parts[2] else ""
+        problem_suffix = f": {problem}" if problem else ""
+        return (
+            "I couldn't use browser tools because browser runtime status is "
+            f"{status}{problem_suffix}. I can use web.search/web.fetch when search "
+            "or fetch can satisfy the request."
+        )
     if any(
         code
         in {
@@ -9454,6 +9479,42 @@ class SessionImplMixin(HandlerMixinBase):
                     ),
                 )
             )
+            if (
+                proposal_tool_name.startswith("browser.")
+                and self._registry.get_tool(canonical_proposal_tool) is None
+            ):
+                final_reason = _browser_runtime_unavailable_rejection_reason(
+                    getattr(self._services, "browser_status", {})
+                )
+                rejected += 1
+                rejection_reasons_for_user.append(final_reason)
+                public_arguments = _redact_sensitive_browser_public_arguments(
+                    proposal.tool_name,
+                    proposal.arguments,
+                    turn_sensitive_browser_values,
+                )
+                await self._event_bus.publish(
+                    ToolRejected(
+                        session_id=sid,
+                        actor="policy_loop",
+                        tool_name=proposal.tool_name,
+                        reason=final_reason,
+                    )
+                )
+                if self._trace_recorder is not None:
+                    trace_tool_calls.append(
+                        TraceToolCall(
+                            tool_name=str(proposal.tool_name),
+                            arguments=dict(public_arguments),
+                            pep_decision="skipped:unregistered_browser_tool",
+                            monitor_decision="skipped:unregistered_browser_tool",
+                            control_plane_decision="skipped:unregistered_browser_tool",
+                            final_decision="reject",
+                            executed=False,
+                            execution_success=False,
+                        )
+                    )
+                continue
             proposal_arguments = await self._prepare_browser_tool_arguments(
                 session=session,
                 tool_name=canonical_proposal_tool,

--- a/src/shisad/daemon/handlers/_impl_tool_execution.py
+++ b/src/shisad/daemon/handlers/_impl_tool_execution.py
@@ -16,6 +16,7 @@ from shisad.core.events import PlanCancelled, PlanCommitted, ToolRejected
 from shisad.core.tools.names import canonical_tool_name
 from shisad.core.types import Capability, SessionId, TaintLabel, ToolName
 from shisad.core.url_parsing import safe_url_hostname
+from shisad.daemon.handlers._impl_session import _browser_runtime_unavailable_rejection_reason
 from shisad.daemon.handlers._mixin_typing import (
     HandlerMixinBase,
 )
@@ -135,6 +136,20 @@ class ToolExecutionImplMixin(HandlerMixinBase):
         tool_name = self._registry.resolve_name(tool_name_value) or ToolName(tool_name_value)
         tool_def = self._registry.get_tool(tool_name)
         if tool_def is None:
+            suppressed_browser_reason = _browser_runtime_unavailable_rejection_reason(
+                getattr(getattr(self, "_services", None), "browser_status", {}),
+                tool_name=tool_name,
+            )
+            if suppressed_browser_reason:
+                await self._event_bus.publish(
+                    ToolRejected(
+                        session_id=sid,
+                        actor="control_api",
+                        tool_name=tool_name,
+                        reason=suppressed_browser_reason,
+                    )
+                )
+                raise ValueError(f"browser runtime unavailable: {suppressed_browser_reason}")
             mcp_manager = getattr(self, "_mcp_manager", None)
             if mcp_manager is not None:
                 startup_error_lookup = getattr(mcp_manager, "startup_error_for_tool", None)

--- a/src/shisad/daemon/services.py
+++ b/src/shisad/daemon/services.py
@@ -303,13 +303,48 @@ def _browser_runtime_unavailable_planner_note(browser_status: dict[str, Any]) ->
         if reason and reason not in problems:
             problems.append(reason)
     reason_text = ", ".join(problems) if problems else "unknown_browser_runtime_problem"
+    problem_set = set(problems)
+    if "browser_command_unconfigured" in problem_set:
+        remediation = (
+            "Ask the user to configure SHISAD_BROWSER_COMMAND or run "
+            "`shisad doctor check --component browser`."
+        )
+    elif problem_set.intersection(
+        {"browser_command_unavailable", "browser_command_protocol_incompatible"}
+    ):
+        remediation = (
+            "Ask the user to check the browser command and wrapper protocol, then "
+            "run `shisad doctor check --component browser`."
+        )
+    elif problem_set.intersection(
+        {
+            "browser_cache_not_writable",
+            "browser_dependency_unavailable",
+            "browser_node_modules_unavailable",
+        }
+    ):
+        remediation = (
+            "Ask the user to fix browser runtime dependencies or cache permissions, "
+            "then run `shisad doctor check --component browser`."
+        )
+    elif problem_set.intersection(
+        {
+            "browser_hardened_wildcard_scope_unsupported",
+            "browser_runtime_isolation_unavailable",
+        }
+    ):
+        remediation = (
+            "Ask the user to fix browser sandbox/isolation settings or browser "
+            "allowed-domain scope, then run `shisad doctor check --component browser`."
+        )
+    else:
+        remediation = "Ask the user to run `shisad doctor check --component browser`."
     return (
         f"Browser tools are unavailable because runtime status is {status}: "
         f"{reason_text}. Browser navigation tools are not registered; use "
         "web.search/web.fetch when search or fetch can satisfy the request, and "
         "tell the user about this browser runtime configuration problem if browser "
-        "navigation is required. Ask the user to configure SHISAD_BROWSER_COMMAND "
-        "or run `shisad doctor check --component browser`."
+        f"navigation is required. {remediation}"
     )
 
 

--- a/src/shisad/daemon/services.py
+++ b/src/shisad/daemon/services.py
@@ -267,6 +267,72 @@ def _build_browser_sandbox(
     )
 
 
+def _browser_toolkit_kwargs(
+    *,
+    config: DaemonConfig,
+    sandbox: SandboxOrchestrator,
+    browser_sandbox: Any,
+    allowed_domains: list[str],
+) -> dict[str, Any]:
+    return {
+        "enabled": bool(config.browser_enabled),
+        "command": config.browser_command,
+        "session_root": config.data_dir / "browser",
+        "allowed_domains": list(allowed_domains),
+        "timeout_seconds": config.browser_timeout_seconds,
+        "require_hardened_isolation": bool(config.browser_require_hardened_isolation),
+        "max_read_bytes": config.browser_max_read_bytes,
+        "sandbox_runner": sandbox,
+        "browser_sandbox": browser_sandbox,
+    }
+
+
+async def _browser_startup_status(
+    *,
+    config: DaemonConfig,
+    sandbox: SandboxOrchestrator,
+    browser_sandbox: Any,
+    allowed_domains: list[str],
+) -> dict[str, Any]:
+    if not config.browser_enabled:
+        return {
+            "enabled": False,
+            "command": "",
+            "allowed_domains": list(allowed_domains),
+            "require_hardened_isolation": bool(config.browser_require_hardened_isolation),
+            "problems": [],
+            "protocol": {"supported": False, "probe": "", "reason": ""},
+            "status": "disabled",
+        }
+    try:
+        from shisad.executors.browser import BrowserToolkit
+
+        toolkit = BrowserToolkit(
+            **_browser_toolkit_kwargs(
+                config=config,
+                sandbox=sandbox,
+                browser_sandbox=browser_sandbox,
+                allowed_domains=allowed_domains,
+            )
+        )
+        return dict(await toolkit.doctor_status())
+    except Exception:
+        logger.exception("Browser startup health check failed")
+        return {
+            "enabled": True,
+            "command": config.browser_command,
+            "allowed_domains": list(allowed_domains),
+            "require_hardened_isolation": bool(config.browser_require_hardened_isolation),
+            "problems": ["browser_doctor_failed"],
+            "protocol": {"supported": False, "probe": "", "reason": "browser_doctor_failed"},
+            "status": "misconfigured",
+        }
+
+
+def _browser_surface_available(browser_status: dict[str, Any]) -> bool:
+    return bool(browser_status.get("enabled")) and browser_status.get("status") == "ok"
+
+
 def _realitycheck_disabled_status(
     *,
     config: DaemonConfig,
@@ -439,6 +505,7 @@ class DaemonServices:
     msgvault_toolkit: MsgvaultToolkit
     realitycheck_toolkit: RealityCheckToolkit
     realitycheck_status: dict[str, Any]
+    browser_status: dict[str, Any]
     lockdown_manager: LockdownManager
     rate_limiter: RateLimiter
     monitor: ActionMonitor
@@ -807,10 +874,23 @@ class DaemonServices:
                 browser_destinations = [
                     item.strip() for item in config.web_allowed_domains if item.strip()
                 ]
+            browser_status = await _browser_startup_status(
+                config=config,
+                sandbox=sandbox,
+                browser_sandbox=browser_sandbox,
+                allowed_domains=browser_destinations,
+            )
+            browser_surface_enabled = _browser_surface_available(browser_status)
+            if config.browser_enabled and not browser_surface_enabled:
+                logger.warning(
+                    "Browser tools not registered because browser runtime is %s: %s",
+                    browser_status.get("status", "unknown"),
+                    ", ".join(str(item) for item in browser_status.get("problems", [])) or "none",
+                )
             registry, alarm_tool = _build_tool_registry(
                 event_bus,
                 web_search_destination=search_backend_destination,
-                browser_surface_enabled=bool(config.browser_enabled),
+                browser_surface_enabled=browser_surface_enabled,
                 browser_destinations=browser_destinations,
                 realitycheck_surface_enabled=bool(
                     realitycheck_status.get("surface_enabled", False)
@@ -925,6 +1005,7 @@ class DaemonServices:
                 msgvault_toolkit=msgvault_toolkit,
                 realitycheck_toolkit=realitycheck_toolkit,
                 realitycheck_status=realitycheck_status,
+                browser_status=browser_status,
                 lockdown_manager=lockdown_manager,
                 rate_limiter=rate_limiter,
                 monitor=monitor,

--- a/src/shisad/daemon/services.py
+++ b/src/shisad/daemon/services.py
@@ -304,41 +304,45 @@ def _browser_runtime_unavailable_planner_note(browser_status: dict[str, Any]) ->
             problems.append(reason)
     reason_text = ", ".join(problems) if problems else "unknown_browser_runtime_problem"
     problem_set = set(problems)
+    remediation_parts: list[str] = []
     if "browser_command_unconfigured" in problem_set:
-        remediation = (
+        remediation_parts.append(
             "Ask the user to configure SHISAD_BROWSER_COMMAND or run "
             "`shisad doctor check --component browser`."
         )
-    elif problem_set.intersection(
+    if problem_set.intersection(
         {"browser_command_unavailable", "browser_command_protocol_incompatible"}
     ):
-        remediation = (
+        remediation_parts.append(
             "Ask the user to check the browser command and wrapper protocol, then "
             "run `shisad doctor check --component browser`."
         )
-    elif problem_set.intersection(
+    if problem_set.intersection(
         {
             "browser_cache_not_writable",
             "browser_dependency_unavailable",
             "browser_node_modules_unavailable",
         }
     ):
-        remediation = (
+        remediation_parts.append(
             "Ask the user to fix browser runtime dependencies or cache permissions, "
             "then run `shisad doctor check --component browser`."
         )
-    elif problem_set.intersection(
+    if problem_set.intersection(
         {
             "browser_hardened_wildcard_scope_unsupported",
             "browser_runtime_isolation_unavailable",
         }
     ):
-        remediation = (
+        remediation_parts.append(
             "Ask the user to fix browser sandbox/isolation settings or browser "
             "allowed-domain scope, then run `shisad doctor check --component browser`."
         )
-    else:
-        remediation = "Ask the user to run `shisad doctor check --component browser`."
+    if not remediation_parts:
+        remediation_parts.append(
+            "Ask the user to run `shisad doctor check --component browser`."
+        )
+    remediation = " ".join(dict.fromkeys(remediation_parts))
     return (
         f"Browser tools are unavailable because runtime status is {status}: "
         f"{reason_text}. Browser navigation tools are not registered; use "

--- a/src/shisad/daemon/services.py
+++ b/src/shisad/daemon/services.py
@@ -953,6 +953,10 @@ class DaemonServices:
                 browser_destinations = [
                     item.strip() for item in config.web_allowed_domains if item.strip()
                 ]
+            if not browser_destinations:
+                browser_destinations = [
+                    rule.host.strip() for rule in policy_loader.policy.egress if rule.host.strip()
+                ]
             browser_status = await _browser_startup_status(
                 config=config,
                 sandbox=sandbox,

--- a/src/shisad/daemon/services.py
+++ b/src/shisad/daemon/services.py
@@ -288,6 +288,41 @@ def _browser_toolkit_kwargs(
     }
 
 
+def _browser_runtime_unavailable_planner_note(browser_status: dict[str, Any]) -> str:
+    if not bool(browser_status.get("enabled")) or browser_status.get("status") == "ok":
+        return ""
+    status = str(browser_status.get("status") or "unknown")
+    problems = [
+        str(item).strip()
+        for item in browser_status.get("problems", [])
+        if str(item).strip()
+    ]
+    protocol = browser_status.get("protocol")
+    if isinstance(protocol, dict):
+        reason = str(protocol.get("reason") or "").strip()
+        if reason and reason not in problems:
+            problems.append(reason)
+    reason_text = ", ".join(problems) if problems else "unknown_browser_runtime_problem"
+    return (
+        f"Browser tools are unavailable because runtime status is {status}: "
+        f"{reason_text}. Browser navigation tools are not registered; use "
+        "web.search/web.fetch when search or fetch can satisfy the request, and "
+        "tell the user about this browser runtime configuration problem if browser "
+        "navigation is required. Ask the user to configure SHISAD_BROWSER_COMMAND "
+        "or run `shisad doctor check --component browser`."
+    )
+
+
+def _browser_status_with_planner_note(browser_status: dict[str, Any]) -> dict[str, Any]:
+    status = dict(browser_status)
+    planner_note = _browser_runtime_unavailable_planner_note(status)
+    if planner_note:
+        status["planner_note"] = planner_note
+    else:
+        status.pop("planner_note", None)
+    return status
+
+
 async def _browser_startup_status(
     *,
     config: DaemonConfig,
@@ -296,15 +331,17 @@ async def _browser_startup_status(
     allowed_domains: list[str],
 ) -> dict[str, Any]:
     if not config.browser_enabled:
-        return {
-            "enabled": False,
-            "command": "",
-            "allowed_domains": list(allowed_domains),
-            "require_hardened_isolation": bool(config.browser_require_hardened_isolation),
-            "problems": [],
-            "protocol": {"supported": False, "probe": "", "reason": ""},
-            "status": "disabled",
-        }
+        return _browser_status_with_planner_note(
+            {
+                "enabled": False,
+                "command": "",
+                "allowed_domains": list(allowed_domains),
+                "require_hardened_isolation": bool(config.browser_require_hardened_isolation),
+                "problems": [],
+                "protocol": {"supported": False, "probe": "", "reason": ""},
+                "status": "disabled",
+            }
+        )
     try:
         from shisad.executors.browser import BrowserToolkit
 
@@ -316,18 +353,24 @@ async def _browser_startup_status(
                 allowed_domains=allowed_domains,
             )
         )
-        return dict(await toolkit.doctor_status())
+        return _browser_status_with_planner_note(dict(await toolkit.doctor_status()))
     except Exception:
         logger.exception("Browser startup health check failed")
-        return {
-            "enabled": True,
-            "command": config.browser_command,
-            "allowed_domains": list(allowed_domains),
-            "require_hardened_isolation": bool(config.browser_require_hardened_isolation),
-            "problems": ["browser_doctor_failed"],
-            "protocol": {"supported": False, "probe": "", "reason": "browser_doctor_failed"},
-            "status": "misconfigured",
-        }
+        return _browser_status_with_planner_note(
+            {
+                "enabled": True,
+                "command": config.browser_command,
+                "allowed_domains": list(allowed_domains),
+                "require_hardened_isolation": bool(config.browser_require_hardened_isolation),
+                "problems": ["browser_doctor_failed"],
+                "protocol": {
+                    "supported": False,
+                    "probe": "",
+                    "reason": "browser_doctor_failed",
+                },
+                "status": "misconfigured",
+            }
+        )
 
 
 def _browser_surface_available(browser_status: dict[str, Any]) -> bool:
@@ -879,10 +922,16 @@ class DaemonServices:
             )
             browser_surface_enabled = _browser_surface_available(browser_status)
             if config.browser_enabled and not browser_surface_enabled:
+                planner_note = str(browser_status.get("planner_note") or "").strip()
+                problems = ", ".join(
+                    str(item) for item in browser_status.get("problems", [])
+                ) or "none"
                 logger.warning(
-                    "Browser tools not registered because browser runtime is %s: %s",
-                    browser_status.get("status", "unknown"),
-                    ", ".join(str(item) for item in browser_status.get("problems", [])) or "none",
+                    planner_note
+                    or (
+                        "Browser tools not registered because browser runtime is "
+                        f"{browser_status.get('status', 'unknown')}: {problems}"
+                    )
                 )
             registry, alarm_tool = _build_tool_registry(
                 event_bus,

--- a/tests/behavioral/test_behavioral_contract.py
+++ b/tests/behavioral/test_behavioral_contract.py
@@ -6827,6 +6827,57 @@ async def test_contract_web_fetch_routes_to_confirmation_not_lockdown(
 
 
 @pytest.mark.asyncio
+async def test_gh47_misconfigured_browser_runtime_is_visible_to_planner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_inputs: list[str] = []
+    captured_tool_names: list[str] = []
+
+    def _misconfigure_browser(config: DaemonConfig) -> None:
+        config.browser_command = ""
+
+    async with _contract_harness_context(
+        tmp_path,
+        monkeypatch,
+        prestart=_misconfigure_browser,
+    ) as harness:
+
+        async def _capture_complete(
+            self: LocalPlannerProvider,
+            messages: list[Message],
+            tools: list[dict[str, Any]] | None = None,
+        ) -> ProviderResponse:
+            if messages:
+                captured_inputs.append(str(messages[-1].content))
+            for tool in tools or []:
+                function = tool.get("function")
+                if isinstance(function, dict):
+                    captured_tool_names.append(str(function.get("name", "")))
+            return await _stub_complete(self, messages, tools)
+
+        monkeypatch.setattr(LocalPlannerProvider, "complete", _capture_complete, raising=True)
+        sid = await _create_session(harness.client)
+        reply = await harness.client.call(
+            "session.message",
+            {"session_id": sid, "content": "which browser tools are available?"},
+        )
+
+    assert reply.get("lockdown_level") == "normal"
+    assert int(reply.get("blocked_actions", 0)) == 0
+    assert int(reply.get("confirmation_required_actions", 0)) == 0
+    assert all(not name.startswith("browser_") for name in captured_tool_names)
+    planner_input = _latest_user_request_planner_input(captured_inputs).replace("^", "")
+    trusted_section = _extract_trusted_context_before_request(planner_input)
+    assert (
+        "Browser tools are unavailable because runtime status is misconfigured"
+        in trusted_section
+    )
+    assert "browser_command_unconfigured" in trusted_section
+    assert "web.search/web.fetch" in trusted_section
+
+
+@pytest.mark.asyncio
 async def test_contract_browser_navigate_executes_and_returns_page(
     contract_harness: ContractHarness,
 ) -> None:

--- a/tests/behavioral/test_behavioral_contract.py
+++ b/tests/behavioral/test_behavioral_contract.py
@@ -14,6 +14,7 @@ import asyncio
 import json
 import os
 import re
+import shutil
 import sqlite3
 import struct
 import subprocess
@@ -1033,6 +1034,14 @@ class ContractHarness:
     browser_base_url: str
 
 
+def _executable_fake_browser_command(tmp_path: Path) -> str:
+    source = Path(__file__).resolve().parents[1] / "fixtures" / "fake_playwright_cli.py"
+    target = tmp_path / "fake_playwright_cli.py"
+    shutil.copy2(source, target)
+    target.chmod(0o755)
+    return str(target)
+
+
 @asynccontextmanager
 async def _contract_harness_context(
     tmp_path: Path,
@@ -1096,10 +1105,7 @@ async def _contract_harness_context(
                 "browser_enabled": web_search_backend_configured
                 if browser_enabled is None
                 else browser_enabled,
-                "browser_command": (
-                    f"{sys.executable} "
-                    f"{Path(__file__).resolve().parents[1] / 'fixtures' / 'fake_playwright_cli.py'}"
-                ),
+                "browser_command": _executable_fake_browser_command(tmp_path),
                 "browser_allowed_domains": browser_allowed_domains or ["127.0.0.1", "localhost"],
                 "browser_require_hardened_isolation": False,
                 "assistant_fs_roots": [workspace_root],

--- a/tests/fixtures/fake_playwright_cli.py
+++ b/tests/fixtures/fake_playwright_cli.py
@@ -929,6 +929,13 @@ def main(argv: list[str] | None = None) -> int:
         raise SystemExit("command required")
 
     command = args.pop(0)
+    if command == "--shisad-browser-wrapper-version":
+        print("shisad-browser-wrapper 2")
+        return 0
+    if command == "--shisad-browser-wrapper-doctor":
+        print("shisad-browser-wrapper doctor ok")
+        return 0
+
     cwd = Path.cwd()
     state = _load_state(cwd, session)
 

--- a/tests/integration/test_cleanroom_workflow.py
+++ b/tests/integration/test_cleanroom_workflow.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import sys
 from contextlib import suppress
 from pathlib import Path
 
@@ -52,6 +53,11 @@ async def _start_daemon(
     await _wait_for_socket(config.socket_path)
     await client.connect()
     return daemon_task, client, config
+
+
+def _fake_browser_command() -> str:
+    fixture = Path(__file__).resolve().parents[1] / "fixtures" / "fake_playwright_cli.py"
+    return f"{sys.executable} {fixture}"
 
 
 async def _shutdown(daemon_task: asyncio.Task[None], client: ControlClient) -> None:
@@ -323,7 +329,13 @@ async def test_gh33_cleanroom_sensitive_browser_proposal_redacts_public_metadata
 
     monkeypatch.setattr(Planner, "propose", _propose_sensitive_browser_type)
 
-    daemon_task, client, config = await _start_daemon(tmp_path)
+    daemon_task, client, config = await _start_daemon(
+        tmp_path,
+        browser_enabled=True,
+        browser_command=_fake_browser_command(),
+        browser_allowed_domains=["127.0.0.1", "localhost"],
+        browser_require_hardened_isolation=False,
+    )
     try:
         created = await client.call(
             "session.create",

--- a/tests/integration/test_scheduler_execution_gate.py
+++ b/tests/integration/test_scheduler_execution_gate.py
@@ -525,7 +525,7 @@ async def test_g3_task_confirmation_replay_updates_scheduler_state_and_outcome(
         assert confirmed["confirmed"] is False
         assert str(confirmed.get("confirmation_id", "")) == confirmation_id
         assert str(confirmed.get("status", "")) == "failed"
-        assert str(confirmed.get("status_reason", "")) == "approve for regression test"
+        assert str(confirmed.get("status_reason", "")) == "channel_not_available"
 
         remaining = await _wait_for_confirmation_to_leave_pending(
             client,
@@ -551,7 +551,7 @@ async def test_g3_task_confirmation_replay_updates_scheduler_state_and_outcome(
             item for item in rows if str(item.get("confirmation_id", "")) == confirmation_id
         )
         assert str(matching.get("status", "")) == "failed"
-        assert str(matching.get("status_reason", "")) == "approve for regression test"
+        assert str(matching.get("status_reason", "")) == "channel_not_available"
     finally:
         await _shutdown_daemon(daemon_task, client)
 

--- a/tests/unit/test_daemon_services.py
+++ b/tests/unit/test_daemon_services.py
@@ -49,6 +49,27 @@ from shisad.skills.artifacts import ArtifactState
 from shisad.skills.manager import InstalledSkill
 
 
+def _write_browser_wrapper(path) -> None:
+    path.write_text(
+        "\n".join(
+            [
+                "#!/usr/bin/env python3",
+                "import sys",
+                "if '--shisad-browser-wrapper-version' in sys.argv:",
+                "    print('shisad-browser-wrapper 2')",
+                "    raise SystemExit(0)",
+                "if '--shisad-browser-wrapper-doctor' in sys.argv:",
+                "    print('shisad-browser-wrapper doctor ok')",
+                "    raise SystemExit(0)",
+                "raise SystemExit(1)",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+
+
 def test_u8_daemon_runner_import_defers_disabled_backend_modules() -> None:
     code = textwrap.dedent(
         """
@@ -1566,20 +1587,51 @@ def test_daemon_config_preserves_ipv6_loopback_approval_origin(tmp_path) -> None
 @pytest.mark.asyncio
 async def test_m6_daemon_services_browser_registry_falls_back_to_web_allowlist(
     tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _clear_remote_provider_env(monkeypatch)
+    wrapper = tmp_path / "shisad-browser-wrapper"
+    _write_browser_wrapper(wrapper)
     config = DaemonConfig(
         data_dir=tmp_path / "data",
         socket_path=tmp_path / "control.sock",
         policy_path=tmp_path / "policy.yaml",
         browser_enabled=True,
+        browser_command=str(wrapper),
         web_allowed_domains=["localhost"],
         browser_allowed_domains=[],
     )
     services = await DaemonServices.build(config)
     try:
+        assert services.browser_status["status"] == "ok"
         navigate_tool = services.registry.get_tool(ToolName("browser.navigate"))
         assert navigate_tool is not None
         assert navigate_tool.destinations == ["localhost"]
+    finally:
+        await services.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_gh_browser_misconfigured_runtime_suppresses_browser_tools(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_remote_provider_env(monkeypatch)
+    config = DaemonConfig(
+        data_dir=tmp_path / "data",
+        socket_path=tmp_path / "control.sock",
+        policy_path=tmp_path / "policy.yaml",
+        browser_enabled=True,
+        browser_command="",
+        web_allowed_domains=["localhost"],
+    )
+
+    services = await DaemonServices.build(config)
+    try:
+        assert services.browser_status["status"] == "misconfigured"
+        assert "browser_command_unconfigured" in services.browser_status["problems"]
+        assert services.registry.get_tool(ToolName("browser.navigate")) is None
+        assert services.registry.get_tool(ToolName("browser.read_page")) is None
     finally:
         await services.shutdown()
 

--- a/tests/unit/test_daemon_services.py
+++ b/tests/unit/test_daemon_services.py
@@ -1602,6 +1602,7 @@ async def test_m6_daemon_services_browser_registry_falls_back_to_web_allowlist(
         policy_path=tmp_path / "policy.yaml",
         browser_enabled=True,
         browser_command=str(wrapper),
+        browser_require_hardened_isolation=False,
         web_allowed_domains=["localhost"],
         browser_allowed_domains=[],
     )

--- a/tests/unit/test_daemon_services.py
+++ b/tests/unit/test_daemon_services.py
@@ -1584,6 +1584,10 @@ def test_daemon_config_preserves_ipv6_loopback_approval_origin(tmp_path) -> None
     assert config.approval_bind_port == 8787
 
 
+async def _build_browser_registry_services(config: DaemonConfig) -> DaemonServices:
+    return await DaemonServices.build(config)
+
+
 @pytest.mark.asyncio
 async def test_m6_daemon_services_browser_registry_falls_back_to_web_allowlist(
     tmp_path,
@@ -1601,7 +1605,7 @@ async def test_m6_daemon_services_browser_registry_falls_back_to_web_allowlist(
         web_allowed_domains=["localhost"],
         browser_allowed_domains=[],
     )
-    services = await DaemonServices.build(config)
+    services = await _build_browser_registry_services(config)
     try:
         assert services.browser_status["status"] == "ok"
         navigate_tool = services.registry.get_tool(ToolName("browser.navigate"))
@@ -1626,7 +1630,7 @@ async def test_gh_browser_misconfigured_runtime_suppresses_browser_tools(
         web_allowed_domains=["localhost"],
     )
 
-    services = await DaemonServices.build(config)
+    services = await _build_browser_registry_services(config)
     try:
         assert services.browser_status["status"] == "misconfigured"
         assert "browser_command_unconfigured" in services.browser_status["problems"]

--- a/tests/unit/test_daemon_services.py
+++ b/tests/unit/test_daemon_services.py
@@ -1652,6 +1652,42 @@ async def test_m6_daemon_services_browser_registry_falls_back_to_web_allowlist(
 
 
 @pytest.mark.asyncio
+async def test_gh47_browser_health_uses_policy_egress_fallback_scope(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_remote_provider_env(monkeypatch)
+    wrapper = tmp_path / "shisad-browser-wrapper"
+    _write_browser_wrapper(wrapper)
+    policy_path = tmp_path / "policy.yaml"
+    policy_path.write_text(
+        'egress:\n  - host: "*.browser.example"\n',
+        encoding="utf-8",
+    )
+    config = DaemonConfig(
+        data_dir=tmp_path / "data",
+        socket_path=tmp_path / "control.sock",
+        policy_path=policy_path,
+        browser_enabled=True,
+        browser_command=str(wrapper),
+        browser_require_hardened_isolation=True,
+        web_allowed_domains=[],
+        browser_allowed_domains=[],
+    )
+    services = await _build_browser_registry_services(config)
+    try:
+        assert services.browser_status["status"] == "misconfigured"
+        assert "*.browser.example" in services.browser_status["allowed_domains"]
+        assert (
+            "browser_hardened_wildcard_scope_unsupported"
+            in services.browser_status["problems"]
+        )
+        assert services.registry.get_tool(ToolName("browser.navigate")) is None
+    finally:
+        await services.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_gh_browser_misconfigured_runtime_suppresses_browser_tools(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/test_daemon_services.py
+++ b/tests/unit/test_daemon_services.py
@@ -1635,6 +1635,12 @@ async def test_gh_browser_misconfigured_runtime_suppresses_browser_tools(
     try:
         assert services.browser_status["status"] == "misconfigured"
         assert "browser_command_unconfigured" in services.browser_status["problems"]
+        assert (
+            "Browser tools are unavailable because runtime status is misconfigured"
+            in services.browser_status["planner_note"]
+        )
+        assert "browser_command_unconfigured" in services.browser_status["planner_note"]
+        assert "web.search/web.fetch" in services.browser_status["planner_note"]
         assert services.registry.get_tool(ToolName("browser.navigate")) is None
         assert services.registry.get_tool(ToolName("browser.read_page")) is None
     finally:

--- a/tests/unit/test_daemon_services.py
+++ b/tests/unit/test_daemon_services.py
@@ -1600,6 +1600,25 @@ def test_gh47_browser_runtime_note_uses_specific_remediation() -> None:
     assert "SHISAD_BROWSER_COMMAND" not in note
 
 
+def test_gh47_browser_runtime_note_keeps_mixed_remediation_paths() -> None:
+    note = _browser_runtime_unavailable_planner_note(
+        {
+            "enabled": True,
+            "status": "misconfigured",
+            "problems": [
+                "browser_hardened_wildcard_scope_unsupported",
+                "browser_command_unconfigured",
+            ],
+            "protocol": {"supported": False, "probe": "", "reason": ""},
+        }
+    )
+
+    assert "browser_hardened_wildcard_scope_unsupported" in note
+    assert "browser_command_unconfigured" in note
+    assert "SHISAD_BROWSER_COMMAND" in note
+    assert "browser sandbox/isolation settings" in note
+
+
 async def _build_browser_registry_services(config: DaemonConfig) -> DaemonServices:
     return await DaemonServices.build(config)
 

--- a/tests/unit/test_daemon_services.py
+++ b/tests/unit/test_daemon_services.py
@@ -23,6 +23,7 @@ from shisad.core.types import Capability, CredentialRef, SessionId, ToolName, Us
 from shisad.daemon.handlers._impl import HandlerImplementation, PendingAction
 from shisad.daemon.services import (
     DaemonServices,
+    _browser_runtime_unavailable_planner_note,
     _build_provider_diagnostics,
     _build_tool_registry,
     _key_gated_acceptance_matrix,
@@ -1582,6 +1583,21 @@ def test_daemon_config_preserves_ipv6_loopback_approval_origin(tmp_path) -> None
     assert config.approval_rp_id == "::1"
     assert config.approval_bind_host == "::1"
     assert config.approval_bind_port == 8787
+
+
+def test_gh47_browser_runtime_note_uses_specific_remediation() -> None:
+    note = _browser_runtime_unavailable_planner_note(
+        {
+            "enabled": True,
+            "status": "misconfigured",
+            "problems": ["browser_runtime_isolation_unavailable"],
+            "protocol": {"supported": False, "probe": "", "reason": ""},
+        }
+    )
+
+    assert "browser_runtime_isolation_unavailable" in note
+    assert "browser sandbox/isolation settings" in note
+    assert "SHISAD_BROWSER_COMMAND" not in note
 
 
 async def _build_browser_registry_services(config: DaemonConfig) -> DaemonServices:

--- a/tests/unit/test_handler_confirmation.py
+++ b/tests/unit/test_handler_confirmation.py
@@ -231,6 +231,7 @@ class _ConfirmationImplHarness(ConfirmationImplMixin):
         allow_amendment: bool = False,
         execute_success: bool = True,
         execution_error: str = "",
+        execution_error_tool_output: bool = True,
     ) -> None:
         self._pending_actions: dict[str, PendingAction] = {}
         self._pending_by_session: dict[SessionId, list[str]] = {}
@@ -267,6 +268,7 @@ class _ConfirmationImplHarness(ConfirmationImplMixin):
         self._evidence_store = EvidenceStore(tmp_path / "evidence", salt=b"a" * 32)
         self._execute_success = execute_success
         self._execution_error = execution_error
+        self._execution_error_tool_output = execution_error_tool_output
         self.persist_calls = 0
         self._pep = PEP(
             PolicyBundle(default_require_confirmation=False),
@@ -348,7 +350,11 @@ class _ConfirmationImplHarness(ConfirmationImplMixin):
                 ),
                 taint_labels={TaintLabel.USER_REVIEWED},
             )
-        elif not self._execute_success and self._execution_error:
+        elif (
+            not self._execute_success
+            and self._execution_error
+            and self._execution_error_tool_output
+        ):
             tool_output = SimpleNamespace(
                 content=json.dumps({"ok": False, "error": self._execution_error}),
                 taint_labels=set(),
@@ -358,6 +364,7 @@ class _ConfirmationImplHarness(ConfirmationImplMixin):
             success=self._execute_success,
             checkpoint_id=None,
             tool_output=tool_output if (self._execute_success or self._execution_error) else None,
+            error=self._execution_error if not self._execute_success else "",
         )
 
     @staticmethod
@@ -2134,6 +2141,32 @@ async def test_gh47_confirmation_preserves_runtime_unavailable_execution_reason(
     assert result["status"] == "failed"
     assert result["status_reason"] == reason
     assert harness._pending_actions["c-1"].status_reason == reason
+
+
+@pytest.mark.asyncio
+async def test_gh47_confirmation_preserves_unstructured_execution_error(
+    tmp_path,
+) -> None:
+    harness = _ConfirmationImplHarness(
+        tmp_path,
+        execute_success=False,
+        execution_error="tool_unavailable",
+        execution_error_tool_output=False,
+    )
+    pending = _pending_action(nonce="expected")
+    harness._pending_actions[pending.confirmation_id] = pending
+
+    result = await harness.do_action_confirm(
+        {
+            "confirmation_id": "c-1",
+            "decision_nonce": "expected",
+            "reason": "planner_action_resolve",
+        }
+    )
+
+    assert result["confirmed"] is False
+    assert result["status_reason"] == "tool_unavailable"
+    assert result["status_reason"] != "planner_action_resolve"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_handler_confirmation.py
+++ b/tests/unit/test_handler_confirmation.py
@@ -230,6 +230,7 @@ class _ConfirmationImplHarness(ConfirmationImplMixin):
         *,
         allow_amendment: bool = False,
         execute_success: bool = True,
+        execution_error: str = "",
     ) -> None:
         self._pending_actions: dict[str, PendingAction] = {}
         self._pending_by_session: dict[SessionId, list[str]] = {}
@@ -265,6 +266,7 @@ class _ConfirmationImplHarness(ConfirmationImplMixin):
         self._transcript_store = TranscriptStore(tmp_path / "sessions")
         self._evidence_store = EvidenceStore(tmp_path / "evidence", salt=b"a" * 32)
         self._execute_success = execute_success
+        self._execution_error = execution_error
         self.persist_calls = 0
         self._pep = PEP(
             PolicyBundle(default_require_confirmation=False),
@@ -346,10 +348,16 @@ class _ConfirmationImplHarness(ConfirmationImplMixin):
                 ),
                 taint_labels={TaintLabel.USER_REVIEWED},
             )
+        elif not self._execute_success and self._execution_error:
+            tool_output = SimpleNamespace(
+                content=json.dumps({"ok": False, "error": self._execution_error}),
+                taint_labels=set(),
+                success=False,
+            )
         return SimpleNamespace(
             success=self._execute_success,
             checkpoint_id=None,
-            tool_output=tool_output if self._execute_success else None,
+            tool_output=tool_output if (self._execute_success or self._execution_error) else None,
         )
 
     @staticmethod
@@ -2099,6 +2107,33 @@ async def test_m4_failed_confirmed_promote_does_not_endorse_artifact(tmp_path) -
         PolicyContext(capabilities={Capability.MEMORY_READ}, session_id=SessionId("s-1")),
     )
     assert decision.kind.value == "require_confirmation"
+
+
+@pytest.mark.asyncio
+async def test_gh47_confirmation_preserves_runtime_unavailable_execution_reason(
+    tmp_path,
+) -> None:
+    reason = "browser_runtime_unavailable:misconfigured:browser_command_unconfigured"
+    harness = _ConfirmationImplHarness(
+        tmp_path,
+        execute_success=False,
+        execution_error=reason,
+    )
+    pending = _pending_action(nonce="expected")
+    pending.tool_name = ToolName("browser.click")
+    pending.arguments = {"target": "continue", "description": "continue"}
+    pending.approval_envelope = _software_approval_envelope(tool_name=pending.tool_name)
+    pending.approval_envelope_hash = approval_envelope_hash(pending.approval_envelope)
+    harness._pending_actions[pending.confirmation_id] = pending
+
+    result = await harness.do_action_confirm(
+        {"confirmation_id": "c-1", "decision_nonce": "expected"}
+    )
+
+    assert result["confirmed"] is False
+    assert result["status"] == "failed"
+    assert result["status_reason"] == reason
+    assert harness._pending_actions["c-1"].status_reason == reason
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_handler_planner_context.py
+++ b/tests/unit/test_handler_planner_context.py
@@ -370,6 +370,31 @@ def test_u5_planner_tool_context_shows_full_details_for_trusted_cli() -> None:
     assert "fs.write (native function: fs_write): Write files" in context
 
 
+def test_gh47_planner_tool_context_hides_runtime_notes_from_public_guest() -> None:
+    tool = ToolDefinition(
+        name=ToolName("web.search"),
+        description="Search web",
+        parameters=[],
+        capabilities_required=[Capability.HTTP_REQUEST],
+    )
+
+    context = _build_planner_tool_context(
+        registry_tools=[tool],
+        capabilities={Capability.HTTP_REQUEST},
+        tool_allowlist=None,
+        trust_level="trusted_guest",
+        runtime_availability_notes=(
+            "Browser tools are unavailable because runtime status is misconfigured: "
+            "browser_command_unconfigured. Ask the user to configure "
+            "SHISAD_BROWSER_COMMAND.",
+        ),
+    )
+
+    assert "Runtime availability notes:" not in context
+    assert "SHISAD_BROWSER_COMMAND" not in context
+    assert "browser_command_unconfigured" not in context
+
+
 def test_c3_planner_tool_context_hides_unavailable_fs_tool_ids_from_shell_description() -> None:
     shell_tool = ToolDefinition(
         name=ToolName("shell.exec"),

--- a/tests/unit/test_impl_structured_tool_branches.py
+++ b/tests/unit/test_impl_structured_tool_branches.py
@@ -1873,6 +1873,12 @@ async def test_m1_message_send_session_branch_rejects_non_scheduler_actor() -> N
     assert result.success is False
     assert result.tool_output is not None
     assert "session_delivery_requires_scheduler_actor" in result.tool_output.content
+    direct_result = HandlerImplementation._tool_execute_result_from_execution(
+        harness,  # type: ignore[arg-type]
+        execution=result,
+        origin=harness._origin_for(session=harness._session, actor="planner"),
+    )
+    assert direct_result["reason"] == "session_delivery_requires_scheduler_actor"
     assert harness._delivery.calls == []
     assert harness._transcript_store.calls == []
     assert harness._control_plane.results == [False]

--- a/tests/unit/test_mcp_interop.py
+++ b/tests/unit/test_mcp_interop.py
@@ -1290,6 +1290,33 @@ async def test_gh47_confirmed_browser_tool_rejects_when_runtime_suppressed() -> 
 
 
 @pytest.mark.asyncio
+async def test_gh47_execute_approved_action_reports_unavailable_unregistered_tool() -> None:
+    harness = _McpHarness(payload={}, register_tool=False)
+
+    result = await HandlerImplementation._execute_approved_action(
+        harness,  # type: ignore[arg-type]
+        sid=harness.session_id,
+        user_id=UserId("alice"),
+        tool_name=ToolName("mcp.docs.lookup-doc"),
+        arguments={"query": "roadmap"},
+        capabilities=set(),
+        approval_actor="human_confirmation",
+    )
+
+    assert result.success is False
+    assert result.error == "tool_unavailable"
+    rejected_events = [
+        event for event in harness._event_bus.events if isinstance(event, ToolRejected)
+    ]
+    executed_events = [
+        event for event in harness._event_bus.events if isinstance(event, ToolExecuted)
+    ]
+    assert rejected_events[-1].reason == "tool_unavailable"
+    assert executed_events[-1].error == "tool_unavailable"
+    assert harness._control_plane.results == [False]
+
+
+@pytest.mark.asyncio
 async def test_i2_execute_approved_action_sanitizes_mcp_prompt_injection_and_preserves_taint() -> (
     None
 ):

--- a/tests/unit/test_mcp_interop.py
+++ b/tests/unit/test_mcp_interop.py
@@ -1255,6 +1255,41 @@ async def test_i1_execute_approved_action_uses_upstream_mcp_tool_name() -> None:
 
 
 @pytest.mark.asyncio
+async def test_gh47_confirmed_browser_tool_rejects_when_runtime_suppressed() -> None:
+    harness = _McpHarness(payload={}, register_tool=False)
+    harness._services = SimpleNamespace(
+        browser_status={
+            "enabled": True,
+            "status": "misconfigured",
+            "problems": ["browser_command_unconfigured"],
+        }
+    )
+
+    result = await HandlerImplementation._execute_approved_action(
+        harness,  # type: ignore[arg-type]
+        sid=harness.session_id,
+        user_id=UserId("alice"),
+        tool_name=ToolName("browser.click"),
+        arguments={"target": "continue", "description": "continue"},
+        capabilities=set(),
+        approval_actor="human_confirmation",
+    )
+
+    assert result.success is False
+    rejected_events = [
+        event for event in harness._event_bus.events if isinstance(event, ToolRejected)
+    ]
+    executed_events = [
+        event for event in harness._event_bus.events if isinstance(event, ToolExecuted)
+    ]
+    assert rejected_events[-1].reason == (
+        "browser_runtime_unavailable:misconfigured:browser_command_unconfigured"
+    )
+    assert executed_events[-1].success is False
+    assert harness._control_plane.results == [False]
+
+
+@pytest.mark.asyncio
 async def test_i2_execute_approved_action_sanitizes_mcp_prompt_injection_and_preserves_taint() -> (
     None
 ):

--- a/tests/unit/test_mcp_interop.py
+++ b/tests/unit/test_mcp_interop.py
@@ -1634,6 +1634,41 @@ async def test_i1_tool_execute_surfaces_mcp_startup_registration_errors(
     )
 
 
+@pytest.mark.asyncio
+async def test_gh47_tool_execute_reports_suppressed_browser_runtime_reason() -> None:
+    harness = _McpHarness(payload={}, register_tool=False)
+    harness._services = SimpleNamespace(
+        browser_status={
+            "enabled": True,
+            "status": "misconfigured",
+            "problems": ["browser_command_unconfigured"],
+        }
+    )
+
+    with pytest.raises(ValueError, match="browser runtime unavailable"):
+        await HandlerImplementation.do_tool_execute(
+            harness,  # type: ignore[arg-type]
+            {
+                "session_id": str(harness.session_id),
+                "tool_name": "browser.click",
+                "command": ["browser.click"],
+                "arguments": {"target": "continue", "description": "continue"},
+                "security_critical": False,
+                "degraded_mode": "fail_open",
+            },
+        )
+
+    assert harness._mcp_manager.calls == []
+    assert any(
+        isinstance(event, ToolRejected)
+        and event.tool_name == ToolName("browser.click")
+        and event.reason == (
+            "browser_runtime_unavailable:misconfigured:browser_command_unconfigured"
+        )
+        for event in harness._event_bus.events
+    )
+
+
 # ---------------------------------------------------------------------------
 # MCP-H1..H5: coverage for MCP security gates.
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_session_message_phases.py
+++ b/tests/unit/test_session_message_phases.py
@@ -1158,6 +1158,114 @@ async def test_gh47_suppressed_browser_tool_rejects_before_argument_prep() -> No
 
 
 @pytest.mark.asyncio
+async def test_gh47_suppressed_browser_tool_feedback_handles_disabled_runtime() -> None:
+    harness = _BrowserSuppressedProposalHarness()
+    harness._services.browser_status = {
+        "enabled": False,
+        "status": "disabled",
+        "problems": [],
+    }
+    validated = _validation_result(
+        params={"session_id": "sess-g1", "content": "browser click continue"}
+    )
+    planner_context = SessionMessagePlannerContextResult(
+        validated=validated,
+        conversation_context="",
+        transcript_context_taints=set(),
+        effective_caps=set(),
+        memory_query="",
+        memory_context="",
+        memory_context_taints=set(),
+        memory_context_tainted_for_amv=False,
+        user_goal_host_patterns=set(),
+        untrusted_current_turn="",
+        untrusted_host_patterns=set(),
+        policy_egress_host_patterns=set(),
+        context=PolicyContext(),
+        planner_origin="planner-origin",
+        committed_plan_hash="plan-g1",
+        active_plan_hash="plan-g1",
+        planner_tools_payload=[],
+        planner_input="planner input",
+        assistant_tone_override=None,
+    )
+    proposal = ActionProposal(
+        action_id="explicit-browser-click",
+        tool_name=ToolName("browser.click"),
+        arguments={"target": "continue", "description": "continue"},
+        reasoning="Execute the user's explicit browser click request.",
+        data_sources=["user_text:explicit_memory_intent"],
+    )
+    planner_dispatch = SessionMessagePlannerDispatchResult(
+        planner_context=planner_context,
+        planner_result=PlannerResult(
+            output=PlannerOutput(
+                assistant_response="Clicking the browser control.",
+                actions=[proposal],
+            ),
+            evaluated=[
+                EvaluatedProposal(
+                    proposal=proposal,
+                    decision=PEPDecision(
+                        kind=PEPDecisionKind.ALLOW,
+                        reason="allow",
+                        tool_name=proposal.tool_name,
+                        risk_score=0.0,
+                    ),
+                )
+            ],
+            attempts=1,
+            provider_response=None,
+            messages_sent=(),
+        ),
+        planner_failure_code="",
+        trace_t0=0.0,
+        delegation_advisory=TaskDelegationRecommendation(
+            delegate=False,
+            action_count=0,
+            reason_codes=(),
+            tools=(),
+        ),
+        trace_tool_calls=[],
+    )
+
+    result = await SessionImplMixin._evaluate_and_execute_actions(harness, planner_dispatch)
+
+    assert result.rejected == 1
+    assert result.executed == 0
+    assert harness.prepare_browser_calls == 0
+    assert result.rejection_reasons_for_user == [
+        "browser_runtime_unavailable:disabled:browser_disabled"
+    ]
+    feedback = impl_session._blocked_action_feedback(result.rejection_reasons_for_user)
+    assert "browser tools are disabled in this daemon configuration" in feedback
+    assert "unknown_browser_runtime_problem" not in feedback
+
+
+def test_gh47_unknown_browser_tool_does_not_claim_runtime_unavailable() -> None:
+    browser_status = {
+        "enabled": True,
+        "status": "misconfigured",
+        "problems": ["browser_command_unconfigured"],
+    }
+
+    assert (
+        impl_session._browser_runtime_unavailable_rejection_reason(
+            browser_status,
+            tool_name="browser.download",
+        )
+        == ""
+    )
+    assert (
+        impl_session._browser_runtime_unavailable_rejection_reason(
+            {"enabled": True, "status": "ok", "problems": []},
+            tool_name="browser.click",
+        )
+        == ""
+    )
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("browser_tool_name", ["browser.type_text", "browser-type-text"])
 async def test_gh33_sensitive_browser_text_redacted_before_control_plane_classifier(
     browser_tool_name: str,

--- a/tests/unit/test_session_message_phases.py
+++ b/tests/unit/test_session_message_phases.py
@@ -2810,6 +2810,8 @@ def _finalize_execution_result(
     pending_confirmation_ids: list[str] | None = None,
     provider_response_model: str | None = None,
     provider_response_trusted_origin: str = "",
+    rejected: int = 0,
+    rejection_reasons_for_user: list[str] | None = None,
 ) -> SessionMessageExecutionResult:
     validated = _validation_result(
         params={"session_id": "sess-g1", "content": content},
@@ -2868,10 +2870,10 @@ def _finalize_execution_result(
     )
     return SessionMessageExecutionResult(
         planner_dispatch=planner_dispatch,
-        rejected=0,
+        rejected=rejected,
         pending_confirmation=pending_confirmation,
         executed=len(tool_outputs),
-        rejection_reasons_for_user=[],
+        rejection_reasons_for_user=list(rejection_reasons_for_user or []),
         checkpoint_ids=[],
         pending_confirmation_ids=list(pending_confirmation_ids or []),
         executed_tool_outputs=tool_outputs,
@@ -3226,6 +3228,27 @@ async def test_finalize_response_synthesizes_after_tool_only_turn() -> None:
     assert any(
         "same turn's tool outputs" in message.content for message in trace_turn.messages_sent
     )
+
+
+@pytest.mark.asyncio
+async def test_gh47_finalize_response_overrides_browser_runtime_rejection_prose() -> None:
+    harness = _FinalizeEvidenceHarness()
+    execution = _finalize_execution_result(
+        tool_outputs=[],
+        assistant_response="Clicking the browser control.",
+        rejected=1,
+        rejection_reasons_for_user=[
+            "browser_runtime_unavailable:misconfigured:browser_command_unconfigured"
+        ],
+    )
+
+    response = await SessionImplMixin._finalize_response(harness, execution)
+
+    text = str(response["response"])
+    assert "browser runtime status is misconfigured" in text
+    assert "browser_command_unconfigured" in text
+    assert "web.search/web.fetch" in text
+    assert "Clicking the browser control" not in text
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_session_message_phases.py
+++ b/tests/unit/test_session_message_phases.py
@@ -1039,6 +1039,124 @@ class _AliasPendingPolicySnapshotHarness(_PendingPolicySnapshotHarness):
         )
 
 
+class _BrowserSuppressedProposalHarness(_PendingPolicySnapshotHarness):
+    def __init__(self) -> None:
+        super().__init__()
+        self.prepare_browser_calls = 0
+        self._services = SimpleNamespace(
+            browser_status={
+                "enabled": True,
+                "status": "misconfigured",
+                "problems": ["browser_command_unconfigured"],
+            }
+        )
+        self._registry = SimpleNamespace(
+            get_tool=lambda tool_name: (
+                None
+                if str(tool_name) == "browser.click"
+                else ToolDefinition(name=ToolName(str(tool_name)), description="tool")
+            )
+        )
+        self._pep = SimpleNamespace(
+            evaluate=lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                AssertionError("PEP should not evaluate unregistered browser tools")
+            )
+        )
+
+    async def _prepare_browser_tool_arguments(
+        self,
+        *,
+        session: object,
+        tool_name: ToolName,
+        arguments: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        _ = (session, tool_name, arguments)
+        self.prepare_browser_calls += 1
+        raise AssertionError("browser argument prep should not run for suppressed tools")
+
+
+@pytest.mark.asyncio
+async def test_gh47_suppressed_browser_tool_rejects_before_argument_prep() -> None:
+    harness = _BrowserSuppressedProposalHarness()
+    validated = _validation_result(
+        params={"session_id": "sess-g1", "content": "browser click continue"}
+    )
+    planner_context = SessionMessagePlannerContextResult(
+        validated=validated,
+        conversation_context="",
+        transcript_context_taints=set(),
+        effective_caps=set(),
+        memory_query="",
+        memory_context="",
+        memory_context_taints=set(),
+        memory_context_tainted_for_amv=False,
+        user_goal_host_patterns=set(),
+        untrusted_current_turn="",
+        untrusted_host_patterns=set(),
+        policy_egress_host_patterns=set(),
+        context=PolicyContext(),
+        planner_origin="planner-origin",
+        committed_plan_hash="plan-g1",
+        active_plan_hash="plan-g1",
+        planner_tools_payload=[],
+        planner_input="planner input",
+        assistant_tone_override=None,
+    )
+    proposal = ActionProposal(
+        action_id="explicit-browser-click",
+        tool_name=ToolName("browser.click"),
+        arguments={"target": "continue", "description": "continue"},
+        reasoning="Execute the user's explicit browser click request.",
+        data_sources=["user_text:explicit_memory_intent"],
+    )
+    planner_dispatch = SessionMessagePlannerDispatchResult(
+        planner_context=planner_context,
+        planner_result=PlannerResult(
+            output=PlannerOutput(
+                assistant_response="Clicking the browser control.",
+                actions=[proposal],
+            ),
+            evaluated=[
+                EvaluatedProposal(
+                    proposal=proposal,
+                    decision=PEPDecision(
+                        kind=PEPDecisionKind.ALLOW,
+                        reason="allow",
+                        tool_name=proposal.tool_name,
+                        risk_score=0.0,
+                    ),
+                )
+            ],
+            attempts=1,
+            provider_response=None,
+            messages_sent=(),
+        ),
+        planner_failure_code="",
+        trace_t0=0.0,
+        delegation_advisory=TaskDelegationRecommendation(
+            delegate=False,
+            action_count=0,
+            reason_codes=(),
+            tools=(),
+        ),
+        trace_tool_calls=[],
+    )
+
+    result = await SessionImplMixin._evaluate_and_execute_actions(harness, planner_dispatch)
+
+    assert result.rejected == 1
+    assert result.executed == 0
+    assert harness.prepare_browser_calls == 0
+    assert harness.control_plane_calls == []
+    assert result.rejection_reasons_for_user == [
+        "browser_runtime_unavailable:misconfigured:browser_command_unconfigured"
+    ]
+    assert (
+        "browser runtime status is misconfigured: browser_command_unconfigured"
+        in impl_session._blocked_action_feedback(result.rejection_reasons_for_user)
+    )
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("browser_tool_name", ["browser.type_text", "browser-type-text"])
 async def test_gh33_sensitive_browser_text_redacted_before_control_plane_classifier(


### PR DESCRIPTION
This is a maintainer integration of #47 by @cryptowooser. The original PR is a draft from a fork with maintainer edits disabled, so this branch preserves the contributor commits as ancestry and layers the reviewed maintainer fixups on top.

Supersedes #47.
Refs #44.

## What changed

- Gate browser tool registration on browser runtime health.
- Add trusted planner/status diagnostics explaining when browser tools are unavailable because runtime status is misconfigured, including web.search/web.fetch fallback guidance.
- Keep browser runtime notes out of public/trusted_guest planner contexts.
- Preserve browser_runtime_unavailable:* reasons across planner proposals, final response shaping, pending confirmations, approved execution, generic failure handling, and direct tool.execute.
- Align startup browser health checks with policy egress fallback scope.

## Validation

- pytest tests/unit/test_mcp_interop.py::test_gh47_tool_execute_reports_suppressed_browser_runtime_reason -q -> 1 passed
- pytest tests/unit/test_mcp_interop.py tests/unit/test_handler_tool_execution.py tests/unit/test_handler_confirmation.py tests/unit/test_session_message_phases.py -q -> 257 passed
- ruff check changed files -> passed
- mypy src/shisad/daemon/handlers/_impl_tool_execution.py -> passed
- git diff --check -> passed
- Earlier PR47 closure evidence includes behavioral planner-visible browser-runtime regression, first-principles gates, broader daemon/browser unit bundles, daemon site guard, and local-only status proof with browser misconfigured and web.search/web.fetch still available.

## Review evidence

- Targeted R2 re-review rv-20260531T121555Z-f2253e32: green
- Final full gate rv-20260531T122014Z-8f45db8c: R1 green, R2 green, R4 green

## Notes

- Related #52/#53 remain separate fallback diagnostics followups.
- #46 is Tabelog-adjacent but separate.
